### PR TITLE
feat: 基本的なボット応答機能を実装

### DIFF
--- a/app/jobs/bot_response_job.rb
+++ b/app/jobs/bot_response_job.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# ボット応答を非同期で処理するジョブ
+class BotResponseJob < ApplicationJob
+  queue_as :high_priority
+
+  # リトライ設定
+  retry_on StandardError, wait: 5.seconds, attempts: 3
+
+  def perform(conversation_id:, user_message_id:)
+    conversation = Conversation.find(conversation_id)
+    user_message = Message.find(user_message_id)
+
+    # ユーザーメッセージであることを確認
+    return unless user_message.role == 'user'
+    return unless user_message.conversation_id == conversation_id
+
+    # ボット応答を生成
+    bot_service = ChatBotService.new(
+      conversation: conversation,
+      user_message: user_message
+    )
+
+    bot_response = bot_service.generate_response
+
+    if bot_response.nil?
+      Rails.logger.error "Failed to generate bot response for message #{user_message_id}"
+      handle_error(conversation, user_message)
+    else
+      # 成功時の追加処理
+      after_response_generated(conversation, bot_response)
+    end
+  rescue ActiveRecord::RecordNotFound => e
+    Rails.logger.error "Record not found: #{e.message}"
+  end
+
+  private
+
+  # エラー時の処理
+  def handle_error(conversation, user_message)
+    # エラー応答を送信
+    error_message = conversation.messages.create!(
+      content: '申し訳ございません。現在システムに問題が発生しています。しばらくしてから再度お試しください。',
+      role: 'assistant',
+      metadata: {
+        error: true,
+        original_message_id: user_message.id
+      }
+    )
+
+    # WebSocketで通知
+    broadcast_error(conversation, error_message)
+  end
+
+  # 応答生成後の処理
+  def after_response_generated(conversation, bot_response)
+    # 会話分析をトリガー（一定間隔で）
+    AnalyzeConversationJob.perform_later(conversation.id) if should_analyze_conversation?(conversation)
+
+    # メトリクスを記録
+    record_metrics(conversation, bot_response)
+  end
+
+  # 会話分析が必要かチェック
+  def should_analyze_conversation?(conversation)
+    # 10メッセージごとに分析
+    (conversation.messages.count % 10).zero?
+  end
+
+  # メトリクスを記録
+  def record_metrics(conversation, bot_response)
+    Rails.logger.info(
+      {
+        event: 'bot_response_generated',
+        conversation_id: conversation.id,
+        response_id: bot_response.id,
+        intent: bot_response.metadata['intent'],
+        confidence: bot_response.metadata['confidence']
+      }.to_json
+    )
+  end
+
+  # エラーをWebSocketで配信
+  def broadcast_error(conversation, error_message)
+    ActionCable.server.broadcast(
+      "conversation_#{conversation.id}",
+      {
+        type: 'bot_error',
+        message: {
+          id: error_message.id,
+          content: error_message.content,
+          role: error_message.role,
+          created_at: error_message.created_at
+        }
+      }
+    )
+  end
+end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -49,6 +49,17 @@ class Conversation < ApplicationRecord
     )
   end
 
+  # ボット機能が有効かチェック
+  def bot_enabled?
+    # metadataまたは設定に基づいて判定
+    metadata&.dig('bot_enabled') != false
+  end
+
+  # 最後のユーザーメッセージを取得
+  def last_user_message
+    messages.user_messages.latest_n(1).first
+  end
+
   private
 
   def generate_session_id

--- a/app/services/chat_bot_service.rb
+++ b/app/services/chat_bot_service.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+# チャットボットの応答生成サービス
+class ChatBotService
+  include ActiveModel::Model
+
+  attr_accessor :conversation, :user_message, :context
+
+  validates :conversation, presence: true
+  validates :user_message, presence: true
+
+  # 応答タイプの定義
+  RESPONSE_TYPES = {
+    greeting: 'greeting',
+    question: 'question',
+    complaint: 'complaint',
+    feedback: 'feedback',
+    general: 'general'
+  }.freeze
+
+  def initialize(conversation:, user_message:, context: {})
+    @conversation = conversation
+    @user_message = user_message
+    @context = context
+  end
+
+  # ボット応答を生成
+  def generate_response # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    return nil unless valid?
+
+    intent = recognize_intent
+    response_content = build_response(intent)
+
+    # 応答メッセージを作成
+    bot_message = conversation.messages.build(
+      content: response_content,
+      role: 'assistant',
+      metadata: {
+        intent: intent[:type],
+        confidence: intent[:confidence],
+        template_used: intent[:template_id]
+      }
+    )
+
+    if bot_message.save
+      broadcast_response(bot_message)
+      bot_message
+    else
+      errors.add(:base, 'ボット応答の保存に失敗しました')
+      nil
+    end
+  rescue StandardError => e
+    Rails.logger.error "Bot response generation failed: #{e.message}"
+    errors.add(:base, 'システムエラーが発生しました')
+    nil
+  end
+
+  # 非同期でボット応答を生成
+  def generate_response_async?
+    return false unless valid?
+
+    BotResponseJob.perform_later(
+      conversation_id: conversation.id,
+      user_message_id: user_message.id
+    )
+    true
+  end
+
+  private
+
+  # 意図を認識
+  def recognize_intent
+    analyzer = IntentRecognizer.new(message: user_message.content)
+    intent_result = analyzer.recognize
+
+    {
+      type: intent_result[:type] || RESPONSE_TYPES[:general],
+      confidence: intent_result[:confidence] || 0.5,
+      keywords: intent_result[:keywords] || [],
+      template_id: nil
+    }
+  end
+
+  # 応答を構築
+  def build_response(intent)
+    template_manager = ResponseTemplates.new(
+      intent_type: intent[:type],
+      context: build_context(intent)
+    )
+
+    response = template_manager.response
+    intent[:template_id] = template_manager.template_id
+
+    response
+  end
+
+  # コンテキストを構築
+  def build_context(intent)
+    {
+      user_name: context[:user_name] || 'お客様',
+      conversation_id: conversation.id,
+      message_count: conversation.messages.count,
+      intent_keywords: intent[:keywords],
+      previous_messages: recent_messages,
+      time_of_day: greeting_time
+    }
+  end
+
+  # 最近のメッセージを取得
+  def recent_messages
+    conversation.messages
+                .latest_n(5)
+                .pluck(:content, :role)
+                .map { |content, role| { content: content, role: role } }
+  end
+
+  # 時間帯に応じた挨拶
+  def greeting_time
+    hour = Time.current.hour
+    case hour
+    when 5..10 then 'morning'
+    when 11..17 then 'afternoon'
+    when 18..22 then 'evening'
+    else 'night'
+    end
+  end
+
+  # WebSocketで応答を配信
+  def broadcast_response(bot_message)
+    ActionCable.server.broadcast(
+      "conversation_#{conversation.id}",
+      {
+        type: 'bot_response',
+        message: {
+          id: bot_message.id,
+          content: bot_message.content,
+          role: bot_message.role,
+          created_at: bot_message.created_at,
+          metadata: bot_message.metadata
+        }
+      }
+    )
+  end
+end

--- a/app/services/intent_recognizer.rb
+++ b/app/services/intent_recognizer.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+# ユーザーメッセージの意図認識クラス
+class IntentRecognizer
+  attr_reader :message
+
+  # キーワードマッピング
+  INTENT_KEYWORDS = {
+    greeting: %w[こんにちは おはよう こんばんは はじめまして よろしく],
+    question: %w[？ ? 教えて どうやって なぜ どうして いつ どこ 何],
+    complaint: %w[困った エラー 動かない おかしい 不具合 バグ 失敗 できない],
+    feedback: %w[改善 提案 要望 意見 フィードバック より良く],
+    thanks: %w[ありがとう 感謝 助かった お礼],
+    goodbye: %w[さようなら またね 失礼 終了 バイバイ]
+  }.freeze
+
+  # 意図の優先順位
+  INTENT_PRIORITY = %i[complaint question greeting feedback thanks goodbye].freeze
+
+  def initialize(message:)
+    @message = message.to_s.downcase
+  end
+
+  # 意図を認識
+  def recognize
+    return { type: 'general', confidence: 0.3, keywords: [] } if @message.blank?
+
+    detected_intents = detect_intents
+
+    if detected_intents.any?
+      best_intent = select_best_intent(detected_intents)
+      {
+        type: best_intent[:type].to_s,
+        confidence: best_intent[:confidence],
+        keywords: best_intent[:keywords]
+      }
+    else
+      {
+        type: 'general',
+        confidence: 0.5,
+        keywords: extract_general_keywords
+      }
+    end
+  end
+
+  # 意図の詳細分析
+  def analyze_sentiment
+    positive_words = %w[嬉しい 良い 素晴らしい 最高 便利 助かる]
+    negative_words = %w[悪い 最悪 ひどい 困る 不満 イライラ]
+
+    positive_score = count_word_matches(positive_words)
+    negative_score = count_word_matches(negative_words)
+
+    if positive_score > negative_score
+      'positive'
+    elsif negative_score > positive_score
+      'negative'
+    else
+      'neutral'
+    end
+  end
+
+  private
+
+  # 意図を検出
+  def detect_intents
+    intents = []
+
+    INTENT_KEYWORDS.each do |intent_type, keywords|
+      matched_keywords = find_matching_keywords(keywords)
+
+      next if matched_keywords.empty?
+
+      confidence = calculate_confidence(matched_keywords, keywords)
+      intents << {
+        type: intent_type,
+        confidence: confidence,
+        keywords: matched_keywords
+      }
+    end
+
+    intents
+  end
+
+  # マッチするキーワードを検索
+  def find_matching_keywords(keywords)
+    keywords.select { |keyword| @message.include?(keyword) }
+  end
+
+  # 信頼度を計算
+  def calculate_confidence(matched_keywords, all_keywords)
+    base_confidence = matched_keywords.size.to_f / all_keywords.size
+
+    # メッセージ長による調整
+    length_factor = [@message.length / 100.0, 1.0].min
+
+    # 複数マッチによるボーナス
+    multi_match_bonus = matched_keywords.size > 1 ? 0.2 : 0
+
+    [(base_confidence + (length_factor * 0.3) + multi_match_bonus), 1.0].min
+  end
+
+  # 最適な意図を選択
+  def select_best_intent(intents)
+    # 優先順位と信頼度を考慮
+    intents.min_by do |intent|
+      priority_index = INTENT_PRIORITY.index(intent[:type]) || INTENT_PRIORITY.size
+      [-intent[:confidence], priority_index]
+    end
+  end
+
+  # 一般的なキーワードを抽出
+  def extract_general_keywords
+    # 重要そうな単語を抽出（簡易版）
+    @message.scan(/[一-龠ぁ-ゔァ-ヴー]{2,}/)
+            .reject { |w| w.length > 10 }
+            .first(3)
+  end
+
+  # 単語マッチ数をカウント
+  def count_word_matches(words)
+    words.count { |word| @message.include?(word) }
+  end
+end

--- a/app/services/response_templates.rb
+++ b/app/services/response_templates.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+# ボット応答テンプレート管理クラス
+class ResponseTemplates
+  attr_reader :intent_type, :context, :template_id
+
+  # テンプレート定義
+  TEMPLATES = {
+    greeting: [
+      'こんにちは、{user_name}！本日はどのようなご用件でしょうか？',
+      '{user_name}、お疲れ様です。何かお手伝いできることはございますか？',
+      'いらっしゃいませ、{user_name}。ご質問やお困りのことがございましたらお聞かせください。'
+    ],
+    question: [
+      'ご質問ありがとうございます。詳しく確認させていただきます。',
+      'お問い合わせいただいた件について、確認いたします。',
+      'ご質問の内容を承りました。順番に回答させていただきます。'
+    ],
+    complaint: [
+      'ご不便をおかけして申し訳ございません。詳細を確認させていただきます。',
+      'お困りの状況について、心よりお詫び申し上げます。すぐに対応させていただきます。',
+      'ご迷惑をおかけして大変申し訳ございません。問題解決に向けて全力で対応いたします。'
+    ],
+    feedback: [
+      '貴重なフィードバックをありがとうございます。',
+      'ご意見をいただき、誠にありがとうございます。サービス改善の参考にさせていただきます。',
+      'フィードバックを共有いただきありがとうございます。今後の改善に活かさせていただきます。'
+    ],
+    general: [
+      'メッセージありがとうございます。どのようにお手伝いできますでしょうか？',
+      'ご連絡ありがとうございます。ご用件をお聞かせください。',
+      'お問い合わせありがとうございます。詳細をお教えいただけますでしょうか？'
+    ]
+  }.freeze
+
+  # 時間帯別の挨拶
+  TIME_GREETINGS = {
+    morning: 'おはようございます',
+    afternoon: 'こんにちは',
+    evening: 'こんばんは',
+    night: 'お疲れ様です'
+  }.freeze
+
+  def initialize(intent_type:, context: {})
+    @intent_type = intent_type.to_sym
+    @context = context
+    @template_id = nil
+  end
+
+  # 応答を取得
+  def response
+    template = select_template
+    personalize_response(template)
+  end
+
+  # 利用可能なテンプレート数を取得
+  def available_templates_count
+    TEMPLATES[@intent_type]&.size || 0
+  end
+
+  private
+
+  # テンプレートを選択
+  def select_template
+    templates = TEMPLATES[@intent_type] || TEMPLATES[:general]
+
+    # コンテキストに基づいて最適なテンプレートを選択
+    template_index = select_best_template_index(templates)
+    @template_id = "#{@intent_type}_#{template_index}"
+
+    templates[template_index]
+  end
+
+  # 最適なテンプレートインデックスを選択
+  def select_best_template_index(templates)
+    # メッセージ数に基づいて変化を持たせる
+    message_count = @context[:message_count] || 0
+
+    # 会話の長さに応じて異なるテンプレートを使用
+    case message_count
+    when 0..2
+      0 # 初回は最初のテンプレート
+    when 3..5
+      [1, templates.size - 1].min # 2番目のテンプレート
+    else
+      rand(templates.size) # ランダムに選択
+    end
+  end
+
+  # 応答をパーソナライズ
+  def personalize_response(template)
+    response = template.dup
+
+    # プレースホルダーを置換
+    response.gsub!('{user_name}', @context[:user_name] || 'お客様')
+
+    # 時間帯の挨拶を追加
+    if @intent_type == :greeting && @context[:time_of_day]
+      time_greeting = TIME_GREETINGS[@context[:time_of_day].to_sym]
+      response = "#{time_greeting}、#{response}" if time_greeting
+    end
+
+    # キーワードに基づく追加情報
+    response = add_keyword_context(response, @context[:intent_keywords]) if @context[:intent_keywords]&.any?
+
+    response
+  end
+
+  # キーワードコンテキストを追加
+  def add_keyword_context(response, keywords)
+    keyword_responses = {
+      '料金' => '料金に関するお問い合わせですね。',
+      '使い方' => '使用方法についてご案内いたします。',
+      'エラー' => 'エラーが発生しているようですね。',
+      '解約' => '解約をご検討されているのですね。',
+      'アップグレード' => 'アップグレードについてご案内いたします。'
+    }
+
+    keywords.each do |keyword|
+      keyword_responses.each do |key, value|
+        return "#{value}#{response}" if keyword.include?(key)
+      end
+    end
+
+    response
+  end
+end

--- a/spec/jobs/bot_response_job_spec.rb
+++ b/spec/jobs/bot_response_job_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BotResponseJob, type: :job do
+  let(:user) { create(:user) }
+  let(:conversation) { create(:conversation, user: user) }
+  let(:user_message) { create(:message, conversation: conversation, content: 'こんにちは', role: 'user') }
+
+  describe '#perform' do
+    context 'with valid parameters' do
+      it 'ボット応答を生成する' do
+        expect do
+          described_class.perform_now(
+            conversation_id: conversation.id,
+            user_message_id: user_message.id
+          )
+        end.to change(Message, :count).by(1)
+
+        bot_message = conversation.messages.assistant_messages.last
+        expect(bot_message).to be_present
+        expect(bot_message.role).to eq('assistant')
+      end
+
+      it 'WebSocket配信を行う' do
+        allow(ActionCable.server).to receive(:broadcast)
+
+        described_class.perform_now(
+          conversation_id: conversation.id,
+          user_message_id: user_message.id
+        )
+
+        expect(ActionCable.server).to have_received(:broadcast).with(
+          "conversation_#{conversation.id}",
+          hash_including(type: 'bot_response')
+        )
+      end
+
+      it '10メッセージごとに分析ジョブをエンキューする' do
+        # 9個のメッセージを作成
+        9.times do
+          create(:message, conversation: conversation, role: 'user')
+        end
+
+        expect do
+          described_class.perform_now(
+            conversation_id: conversation.id,
+            user_message_id: user_message.id
+          )
+        end.to have_enqueued_job(AnalyzeConversationJob)
+          .with(conversation.id)
+      end
+    end
+
+    context 'with assistant message' do
+      it 'アシスタントメッセージの場合は処理しない' do
+        assistant_message = create(:message,
+                                   conversation: conversation,
+                                   content: '承知しました',
+                                   role: 'assistant')
+
+        expect do
+          described_class.perform_now(
+            conversation_id: conversation.id,
+            user_message_id: assistant_message.id
+          )
+        end.not_to change(Message, :count)
+      end
+    end
+
+    context 'with different conversation' do
+      it '異なる会話のメッセージの場合は処理しない' do
+        other_conversation = create(:conversation, user: user)
+        other_message = create(:message,
+                               conversation: other_conversation,
+                               content: 'test',
+                               role: 'user')
+
+        expect do
+          described_class.perform_now(
+            conversation_id: conversation.id,
+            user_message_id: other_message.id
+          )
+        end.not_to change(Message, :count)
+      end
+    end
+
+    context 'with errors' do
+      it 'エラー時はエラーメッセージを作成する' do
+        chat_bot_service = instance_double(ChatBotService, generate_response: nil)
+        allow(ChatBotService).to receive(:new).and_return(chat_bot_service)
+
+        expect do
+          described_class.perform_now(
+            conversation_id: conversation.id,
+            user_message_id: user_message.id
+          )
+        end.to change(Message, :count).by(1)
+
+        error_message = conversation.messages.last
+        expect(error_message.content).to include('申し訳ございません')
+        expect(error_message.metadata['error']).to be true
+      end
+
+      it 'エラー時はWebSocketでエラー通知を配信する' do
+        chat_bot_service = instance_double(ChatBotService, generate_response: nil)
+        allow(ChatBotService).to receive(:new).and_return(chat_bot_service)
+        allow(ActionCable.server).to receive(:broadcast)
+
+        described_class.perform_now(
+          conversation_id: conversation.id,
+          user_message_id: user_message.id
+        )
+
+        expect(ActionCable.server).to have_received(:broadcast).with(
+          "conversation_#{conversation.id}",
+          hash_including(type: 'bot_error')
+        )
+      end
+    end
+
+    context 'with not found records' do
+      it '存在しない会話IDの場合はエラーログを出力' do
+        allow(Rails.logger).to receive(:error)
+
+        described_class.perform_now(
+          conversation_id: 999_999,
+          user_message_id: user_message.id
+        )
+
+        expect(Rails.logger).to have_received(:error).with(/Record not found/)
+      end
+
+      it '存在しないメッセージIDの場合はエラーログを出力' do
+        allow(Rails.logger).to receive(:error)
+
+        described_class.perform_now(
+          conversation_id: conversation.id,
+          user_message_id: 999_999
+        )
+
+        expect(Rails.logger).to have_received(:error).with(/Record not found/)
+      end
+    end
+  end
+
+  describe 'retry behavior' do
+    it 'StandardErrorでリトライする' do
+      expect do
+        described_class.perform_later(
+          conversation_id: conversation.id,
+          user_message_id: user_message.id
+        )
+      end.to have_enqueued_job(described_class)
+    end
+  end
+end

--- a/spec/services/chat_bot_service_spec.rb
+++ b/spec/services/chat_bot_service_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ChatBotService, type: :service do
+  let(:user) { create(:user) }
+  let(:conversation) { create(:conversation, user: user) }
+  let(:user_message) { create(:message, conversation: conversation, content: 'こんにちは', role: 'user') }
+
+  describe '#initialize' do
+    it '正しく初期化される' do
+      service = described_class.new(
+        conversation: conversation,
+        user_message: user_message
+      )
+
+      expect(service.conversation).to eq(conversation)
+      expect(service.user_message).to eq(user_message)
+    end
+  end
+
+  describe '#generate_response' do
+    context 'with valid parameters' do
+      it 'ボット応答を生成する' do
+        service = described_class.new(
+          conversation: conversation,
+          user_message: user_message
+        )
+
+        response = service.generate_response
+
+        expect(response).to be_a(Message)
+        expect(response.role).to eq('assistant')
+        expect(response.conversation).to eq(conversation)
+      end
+
+      it 'メタデータに意図情報を含む' do
+        service = described_class.new(
+          conversation: conversation,
+          user_message: user_message
+        )
+
+        response = service.generate_response
+
+        expect(response.metadata).to include('intent')
+        expect(response.metadata).to include('confidence')
+        expect(response.metadata).to include('template_used')
+      end
+
+      it 'WebSocket配信を行う' do
+        service = described_class.new(
+          conversation: conversation,
+          user_message: user_message
+        )
+
+        allow(ActionCable.server).to receive(:broadcast)
+
+        service.generate_response
+
+        expect(ActionCable.server).to have_received(:broadcast).with(
+          "conversation_#{conversation.id}",
+          hash_including(type: 'bot_response')
+        )
+      end
+    end
+
+    context 'with invalid parameters' do
+      it '会話がnilの場合はnilを返す' do
+        service = described_class.new(
+          conversation: nil,
+          user_message: user_message
+        )
+
+        expect(service.generate_response).to be_nil
+        expect(service.errors[:conversation]).to include("can't be blank")
+      end
+
+      it 'メッセージがnilの場合はnilを返す' do
+        service = described_class.new(
+          conversation: conversation,
+          user_message: nil
+        )
+
+        expect(service.generate_response).to be_nil
+        expect(service.errors[:user_message]).to include("can't be blank")
+      end
+    end
+
+    context 'with different intents' do
+      it '挨拶メッセージに適切に応答する' do
+        greeting_message = create(:message,
+                                  conversation: conversation,
+                                  content: 'おはようございます',
+                                  role: 'user')
+
+        service = described_class.new(
+          conversation: conversation,
+          user_message: greeting_message
+        )
+
+        response = service.generate_response
+        expect(response.content).to include('お')
+      end
+
+      it '質問に適切に応答する' do
+        question_message = create(:message,
+                                  conversation: conversation,
+                                  content: 'どうやって使いますか？',
+                                  role: 'user')
+
+        service = described_class.new(
+          conversation: conversation,
+          user_message: question_message
+        )
+
+        response = service.generate_response
+        expect(response.metadata['intent']).to eq('question')
+      end
+    end
+  end
+
+  describe '#generate_response_async' do
+    it '非同期ジョブをエンキューする' do
+      service = described_class.new(
+        conversation: conversation,
+        user_message: user_message
+      )
+
+      expect do
+        service.generate_response_async?
+      end.to have_enqueued_job(BotResponseJob)
+        .with(conversation_id: conversation.id, user_message_id: user_message.id)
+    end
+
+    it '無効なパラメータの場合はジョブをエンキューしない' do
+      service = described_class.new(
+        conversation: nil,
+        user_message: user_message
+      )
+
+      expect { service.generate_response_async? }.not_to have_enqueued_job(BotResponseJob)
+    end
+  end
+end

--- a/spec/services/intent_recognizer_spec.rb
+++ b/spec/services/intent_recognizer_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IntentRecognizer, type: :service do
+  describe '#recognize' do
+    context 'with greeting messages' do
+      it '挨拶を認識する' do
+        recognizer = described_class.new(message: 'こんにちは、お元気ですか？')
+        result = recognizer.recognize
+
+        expect(result[:type]).to eq('greeting')
+        expect(result[:confidence]).to be > 0.5
+        expect(result[:keywords]).to include('こんにちは')
+      end
+
+      it '朝の挨拶を認識する' do
+        recognizer = described_class.new(message: 'おはようございます')
+        result = recognizer.recognize
+
+        expect(result[:type]).to eq('greeting')
+      end
+    end
+
+    context 'with question messages' do
+      it '質問を認識する' do
+        recognizer = described_class.new(message: 'これはどうやって使いますか？')
+        result = recognizer.recognize
+
+        expect(result[:type]).to eq('question')
+        expect(result[:keywords]).to include('どうやって')
+      end
+
+      it '疑問符を含む質問を認識する' do
+        recognizer = described_class.new(message: '料金はいくらですか？')
+        result = recognizer.recognize
+
+        expect(result[:type]).to eq('question')
+      end
+    end
+
+    context 'with complaint messages' do
+      it '苦情を認識する' do
+        recognizer = described_class.new(message: 'エラーが発生して困っています')
+        result = recognizer.recognize
+
+        expect(result[:type]).to eq('complaint')
+        expect(result[:keywords]).to include('エラー')
+        expect(result[:keywords]).to include('困った')
+      end
+
+      it '不具合報告を認識する' do
+        recognizer = described_class.new(message: 'アプリが動かない')
+        result = recognizer.recognize
+
+        expect(result[:type]).to eq('complaint')
+      end
+    end
+
+    context 'with feedback messages' do
+      it 'フィードバックを認識する' do
+        recognizer = described_class.new(message: 'UIを改善してほしいという要望があります')
+        result = recognizer.recognize
+
+        expect(result[:type]).to eq('feedback')
+        expect(result[:keywords]).to include('改善')
+        expect(result[:keywords]).to include('要望')
+      end
+    end
+
+    context 'with general messages' do
+      it '一般的なメッセージを認識する' do
+        recognizer = described_class.new(message: '今日は良い天気ですね')
+        result = recognizer.recognize
+
+        expect(result[:type]).to eq('general')
+        expect(result[:confidence]).to be >= 0.3
+      end
+    end
+
+    context 'with empty messages' do
+      it '空のメッセージを処理する' do
+        recognizer = described_class.new(message: '')
+        result = recognizer.recognize
+
+        expect(result[:type]).to eq('general')
+        expect(result[:confidence]).to eq(0.3)
+        expect(result[:keywords]).to be_empty
+      end
+
+      it 'nilメッセージを処理する' do
+        recognizer = described_class.new(message: nil)
+        result = recognizer.recognize
+
+        expect(result[:type]).to eq('general')
+      end
+    end
+
+    context 'with multiple intents' do
+      it '優先順位に基づいて意図を選択する' do
+        recognizer = described_class.new(message: 'こんにちは、エラーで困っています')
+        result = recognizer.recognize
+
+        # complaint が greeting より優先される
+        expect(result[:type]).to eq('complaint')
+      end
+    end
+  end
+
+  describe '#analyze_sentiment' do
+    it 'ポジティブな感情を分析する' do
+      recognizer = described_class.new(message: '素晴らしいサービスで嬉しいです')
+      sentiment = recognizer.analyze_sentiment
+
+      expect(sentiment).to eq('positive')
+    end
+
+    it 'ネガティブな感情を分析する' do
+      recognizer = described_class.new(message: '最悪のサービスで不満です')
+      sentiment = recognizer.analyze_sentiment
+
+      expect(sentiment).to eq('negative')
+    end
+
+    it 'ニュートラルな感情を分析する' do
+      recognizer = described_class.new(message: '今日は月曜日です')
+      sentiment = recognizer.analyze_sentiment
+
+      expect(sentiment).to eq('neutral')
+    end
+  end
+end

--- a/spec/services/response_templates_spec.rb
+++ b/spec/services/response_templates_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ResponseTemplates, type: :service do
+  describe '#response' do
+    context 'with greeting intent' do
+      it '挨拶テンプレートを返す' do
+        templates = described_class.new(
+          intent_type: :greeting,
+          context: { user_name: '田中様' }
+        )
+
+        response = templates.response
+        expect(response).to include('田中様')
+        expect(response).to match(/こんにちは|いらっしゃいませ|お疲れ様/)
+      end
+
+      it '時間帯に応じた挨拶を追加する' do
+        templates = described_class.new(
+          intent_type: :greeting,
+          context: { user_name: '山田様', time_of_day: 'morning' }
+        )
+
+        response = templates.response
+        expect(response).to include('おはようございます')
+      end
+    end
+
+    context 'with question intent' do
+      it '質問テンプレートを返す' do
+        templates = described_class.new(
+          intent_type: :question,
+          context: {}
+        )
+
+        response = templates.response
+        expect(response).to match(/ご質問|お問い合わせ|確認/)
+      end
+    end
+
+    context 'with complaint intent' do
+      it '苦情対応テンプレートを返す' do
+        templates = described_class.new(
+          intent_type: :complaint,
+          context: {}
+        )
+
+        response = templates.response
+        expect(response).to match(/申し訳|お詫び|ご不便/)
+      end
+    end
+
+    context 'with feedback intent' do
+      it 'フィードバックテンプレートを返す' do
+        templates = described_class.new(
+          intent_type: :feedback,
+          context: {}
+        )
+
+        response = templates.response
+        expect(response).to match(/フィードバック|ご意見|改善/)
+      end
+    end
+
+    context 'with general intent' do
+      it '一般テンプレートを返す' do
+        templates = described_class.new(
+          intent_type: :general,
+          context: {}
+        )
+
+        response = templates.response
+        expect(response).to match(/メッセージ|ご連絡|お問い合わせ/)
+      end
+    end
+
+    context 'with unknown intent' do
+      it '一般テンプレートを返す' do
+        templates = described_class.new(
+          intent_type: :unknown,
+          context: {}
+        )
+
+        response = templates.response
+        expect(response).to match(/メッセージ|ご連絡|お問い合わせ/)
+      end
+    end
+
+    context 'with keyword context' do
+      it 'キーワードに基づく追加情報を含む' do
+        templates = described_class.new(
+          intent_type: :question,
+          context: { intent_keywords: ['料金'] }
+        )
+
+        response = templates.response
+        expect(response).to include('料金に関するお問い合わせですね')
+      end
+
+      it 'エラーキーワードに反応する' do
+        templates = described_class.new(
+          intent_type: :complaint,
+          context: { intent_keywords: ['エラー'] }
+        )
+
+        response = templates.response
+        expect(response).to include('エラーが発生しているようですね')
+      end
+    end
+
+    context 'with message count context' do
+      it '初回メッセージには最初のテンプレートを使用' do
+        templates = described_class.new(
+          intent_type: :greeting,
+          context: { message_count: 0 }
+        )
+
+        allow(templates).to receive(:select_best_template_index).and_return(0)
+        templates.response
+        expect(templates.template_id).to eq('greeting_0')
+      end
+
+      it '複数メッセージ後は異なるテンプレートを使用' do
+        templates = described_class.new(
+          intent_type: :greeting,
+          context: { message_count: 4 }
+        )
+
+        response = templates.response
+        expect(response).to be_present
+      end
+    end
+  end
+
+  describe '#available_templates_count' do
+    it '利用可能なテンプレート数を返す' do
+      templates = described_class.new(intent_type: :greeting, context: {})
+      expect(templates.available_templates_count).to eq(3)
+    end
+
+    it '未定義の意図の場合は0を返す' do
+      templates = described_class.new(intent_type: :unknown, context: {})
+      expect(templates.available_templates_count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
- ChatBotService: ボット応答生成サービス
- IntentRecognizer: ユーザーの意図認識機能
- ResponseTemplates: テンプレートベースの応答管理
- BotResponseJob: 非同期応答処理
- ChatChannelにボット応答機能を統合
- 包括的なRSpecテストを追加