### PR TITLE
新規顧客に対するチャットを実装

### DIFF
--- a/frontend/src/CategorySelector.tsx
+++ b/frontend/src/CategorySelector.tsx
@@ -1,0 +1,208 @@
+import React from 'react';
+import { 
+  Briefcase, 
+  Code, 
+  TrendingUp, 
+  Users, 
+  DollarSign, 
+  Award, 
+  MessageCircle 
+} from 'lucide-react';
+
+interface CategorySelectorProps {
+  onSelect: (category: string) => void;
+}
+
+const CategorySelector: React.FC<CategorySelectorProps> = ({ onSelect }) => {
+  const categories = [
+    {
+      id: 'service',
+      title: 'サービス概要・能力範囲',
+      icon: Briefcase,
+      color: '#3b82f6',
+      bgColor: '#dbeafe',
+      questions: [
+        'マーケティング戦略とシステム構築、どこまで対応可能？',
+        'ワンストップサービスの具体的な流れは？',
+        '他社との差別化ポイントは？'
+      ]
+    },
+    {
+      id: 'tech',
+      title: '技術・システム関連',
+      icon: Code,
+      color: '#8b5cf6',
+      bgColor: '#e9d5ff',
+      questions: [
+        'どんなシステム開発が得意？',
+        '既存システムとの連携は可能？',
+        '開発期間・工数の目安は？',
+        '保守・運用サポートはある？'
+      ]
+    },
+    {
+      id: 'marketing',
+      title: 'マーケティング戦略',
+      icon: TrendingUp,
+      color: '#10b981',
+      bgColor: '#d1fae5',
+      questions: [
+        '業界別のマーケティング事例はある？',
+        'デジタルマーケティングの成果測定方法は？',
+        'SEO・広告運用も対応可能？'
+      ]
+    },
+    {
+      id: 'project',
+      title: 'プロジェクト進行・体制',
+      icon: Users,
+      color: '#f59e0b',
+      bgColor: '#fed7aa',
+      questions: [
+        'プロジェクトの進め方は？',
+        '担当チームの構成は？',
+        '進捗管理・報告頻度は？'
+      ]
+    },
+    {
+      id: 'cost',
+      title: '費用・契約',
+      icon: DollarSign,
+      color: '#ef4444',
+      bgColor: '#fee2e2',
+      questions: [
+        '料金体系・見積もり依頼',
+        '契約期間・支払い条件',
+        '追加費用が発生するケースは？'
+      ]
+    },
+    {
+      id: 'case',
+      title: '実績・事例',
+      icon: Award,
+      color: '#06b6d4',
+      bgColor: '#cffafe',
+      questions: [
+        '同業界での導入事例は？',
+        'ROI・成果事例を知りたい',
+        'クライアント規模別の対応実績'
+      ]
+    },
+    {
+      id: 'consultation',
+      title: '初回相談・問い合わせ',
+      icon: MessageCircle,
+      color: '#ec4899',
+      bgColor: '#fce7f3',
+      questions: [
+        'まず何から相談すれば良い？',
+        '無料相談の範囲は？',
+        '提案資料の作成は可能？'
+      ]
+    }
+  ];
+
+  return (
+    <div style={{
+      backgroundColor: 'white',
+      borderRadius: '0.75rem',
+      padding: '1.5rem',
+      marginBottom: '1rem',
+      boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)'
+    }}>
+      {/* ヘッダー */}
+      <div style={{ marginBottom: '1.5rem', textAlign: 'center' }}>
+        <h3 style={{
+          fontSize: '1.125rem',
+          fontWeight: '600',
+          color: '#1f2937',
+          marginBottom: '0.5rem'
+        }}>
+          お問い合わせありがとうございます
+        </h3>
+        <p style={{
+          fontSize: '0.875rem',
+          color: '#6b7280'
+        }}>
+          以下のカテゴリーの中からお選びください
+        </p>
+      </div>
+
+      {/* カテゴリーグリッド */}
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+        gap: '0.75rem'
+      }}>
+        {categories.map((category) => {
+          const Icon = category.icon;
+          return (
+            <button
+              key={category.id}
+              onClick={() => onSelect(category.id)}
+              style={{
+                padding: '1rem',
+                backgroundColor: 'white',
+                border: '1px solid #e5e7eb',
+                borderRadius: '0.5rem',
+                cursor: 'pointer',
+                transition: 'all 0.2s',
+                textAlign: 'left',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '0.5rem'
+              }}
+              onMouseOver={(e) => {
+                e.currentTarget.style.borderColor = category.color;
+                e.currentTarget.style.backgroundColor = '#f9fafb';
+                e.currentTarget.style.transform = 'translateY(-2px)';
+                e.currentTarget.style.boxShadow = '0 4px 6px rgba(0, 0, 0, 0.1)';
+              }}
+              onMouseOut={(e) => {
+                e.currentTarget.style.borderColor = '#e5e7eb';
+                e.currentTarget.style.backgroundColor = 'white';
+                e.currentTarget.style.transform = 'translateY(0)';
+                e.currentTarget.style.boxShadow = 'none';
+              }}
+            >
+              {/* アイコン */}
+              <div style={{
+                width: '2.5rem',
+                height: '2.5rem',
+                backgroundColor: category.bgColor,
+                borderRadius: '0.375rem',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center'
+              }}>
+                <Icon size={20} color={category.color} />
+              </div>
+
+              {/* タイトル */}
+              <div style={{
+                fontSize: '0.875rem',
+                fontWeight: '600',
+                color: '#1f2937'
+              }}>
+                {category.title}
+              </div>
+
+              {/* サンプル質問（最初の1つを表示） */}
+              <div style={{
+                fontSize: '0.75rem',
+                color: '#9ca3af',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap'
+              }}>
+                例: {category.questions[0]}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default CategorySelector;

--- a/frontend/src/ChatWithSelector.tsx
+++ b/frontend/src/ChatWithSelector.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import CustomerTypeSelector from './CustomerTypeSelector';
 import Chatbot from './Chatbot';
+import NewCustomerChat from './NewCustomerChat';
 
 const ChatWithSelector: React.FC = () => {
   const [customerType, setCustomerType] = useState<'new' | 'existing' | null>(null);
@@ -14,7 +15,12 @@ const ChatWithSelector: React.FC = () => {
     return <CustomerTypeSelector onSelect={handleCustomerTypeSelect} />;
   }
 
-  // 顧客タイプが選択されたらチャット画面を表示
+  // 新規顧客の場合はNewCustomerChatを表示
+  if (customerType === 'new') {
+    return <NewCustomerChat />;
+  }
+
+  // 既存顧客の場合は通常のChatbot画面を表示
   return (
     <div style={{ position: 'relative' }}>
       {/* 顧客タイプ表示バー */}
@@ -23,19 +29,19 @@ const ChatWithSelector: React.FC = () => {
         top: 0,
         left: 0,
         right: 0,
-        backgroundColor: customerType === 'new' ? '#dbeafe' : '#dcfce7',
+        backgroundColor: '#dcfce7',
         padding: '0.5rem',
         textAlign: 'center',
         borderBottom: '1px solid',
-        borderColor: customerType === 'new' ? '#93c5fd' : '#86efac',
+        borderColor: '#86efac',
         zIndex: 100
       }}>
         <span style={{
           fontSize: '0.875rem',
           fontWeight: '500',
-          color: customerType === 'new' ? '#1e40af' : '#166534'
+          color: '#166534'
         }}>
-          {customerType === 'new' ? '🆕 新規のお客様' : '✅ 既存のお客様'}
+          ✅ 既存のお客様
         </span>
       </div>
       

--- a/frontend/src/NewCustomerChat.tsx
+++ b/frontend/src/NewCustomerChat.tsx
@@ -1,0 +1,704 @@
+import React, { useState, useEffect } from 'react';
+import { Send, MessageCircle, User, Mail, Building, Phone } from 'lucide-react';
+import CategorySelector from './CategorySelector';
+import { generateAIResponse } from './companyKnowledge';
+
+interface Message {
+  id: number;
+  text: string;
+  sender: 'user' | 'bot';
+  timestamp: Date;
+  category?: string;
+}
+
+const NewCustomerChat: React.FC = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [inputMessage, setInputMessage] = useState('');
+  const [showCategorySelector, setShowCategorySelector] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showContactForm, setShowContactForm] = useState(false);
+  const [messageCount, setMessageCount] = useState(0);
+  const [contactForm, setContactForm] = useState({
+    name: '',
+    company: '',
+    email: '',
+    phone: '',
+    message: ''
+  });
+  const [formErrors, setFormErrors] = useState({
+    name: '',
+    company: '',
+    email: '',
+    message: ''
+  });
+
+  const categoryNames: { [key: string]: string } = {
+    service: 'サービス概要・能力範囲',
+    tech: '技術・システム関連',
+    marketing: 'マーケティング戦略',
+    project: 'プロジェクト進行・体制',
+    cost: '費用・契約',
+    case: '実績・事例',
+    consultation: '初回相談・問い合わせ'
+  };
+
+  const categoryResponses: { [key: string]: string[] } = {
+    service: [
+      'サービス概要についてご質問ですね。弊社はマーケティング戦略の立案からシステム開発まで、ワンストップでご提供しております。',
+      '【サービス概要】\n・マーケティング戦略立案：市場分析、競合分析、ターゲット設定\n・システム開発：Webアプリ、モバイルアプリ、業務システム\n・デジタルマーケティング：SEO対策、広告運用、SNS運用\n\n【能力範囲】\n・企画から実装、運用まで一貫したサポート\n・AIを活用した効率的なソリューション\n・業界特化型のカスタマイズ対応',
+      'お客様の現在の課題や、どのようなサービスをお探しでしょうか？具体的にお聞かせいただければ、最適なプランをご提案させていただきます。'
+    ],
+    tech: [
+      '技術・システムについてのご質問ですね。弊社は最新技術を活用したシステム開発を得意としています。',
+      '【対応技術】\n・フロントエンド：React, Vue.js, Next.js\n・バックエンド：Ruby on Rails, Node.js, Python\n・クラウド：AWS, Google Cloud, Azure\n・AI/ML：ChatGPT API, Claude API, 機械学習モデル構築\n\n【開発実績】\n・ECサイト構築\n・業務効率化システム\n・AIチャットボット',
+      'どのようなシステムの開発をご検討されていますか？既存システムとの連携など、具体的な要件をお聞かせください。'
+    ],
+    marketing: [
+      'マーケティング戦略についてご興味をお持ちいただきありがとうございます。',
+      '【マーケティングサービス】\n・デジタルマーケティング戦略立案\n・SEO対策・コンテンツマーケティング\n・リスティング広告・SNS広告運用\n・MA/CRMツール導入支援\n\n【分析・改善】\n・アクセス解析・CVR改善\n・A/Bテスト実施\n・KPI設定と効果測定',
+      'どのような商品・サービスのマーケティングをお考えですか？ターゲット層や現在の課題をお聞かせください。'
+    ],
+    project: [
+      'プロジェクトの進め方についてご説明いたします。',
+      '【プロジェクト進行】\n1. ヒアリング・要件定義（1-2週間）\n2. 提案・見積もり（1週間）\n3. 設計・デザイン（2-4週間）\n4. 開発・実装（1-3ヶ月）\n5. テスト・納品（2週間）\n\n【体制】\n・専任PM配置\n・週次進捗報告\n・チャットツールでの随時連絡',
+      'プロジェクトの規模感や希望納期はございますか？お客様のご要望に合わせて体制を組ませていただきます。'
+    ],
+    cost: [
+      '費用・契約についてご質問ですね。',
+      '【料金体系】\n・初期開発費：要件により個別見積もり\n・月額保守費：初期費用の10-15%程度\n・スポット対応：時間単価制\n\n【契約形態】\n・請負契約\n・準委任契約（SES）\n・月額サブスクリプション\n\n【お支払い】\n・分割払い対応可\n・着手金30%、納品時70%',
+      'ご予算の規模感はお決まりでしょうか？まずは無料でお見積もりをさせていただきますので、ご要望をお聞かせください。'
+    ],
+    case: [
+      '実績・事例についてご興味をお持ちいただきありがとうございます。',
+      '【導入事例】\n・小売業A社：ECサイト構築でCVR200%向上\n・製造業B社：業務システムで作業時間50%削減\n・サービス業C社：AIチャットボットで問い合わせ対応80%自動化\n\n【対応業界】\n・小売・EC\n・製造・物流\n・金融・不動産\n・医療・ヘルスケア',
+      'どちらの業界の事例にご興味がございますか？類似事例の詳細をご案内させていただきます。'
+    ],
+    consultation: [
+      '初回相談についてご案内いたします。',
+      '【無料相談の内容】\n・課題のヒアリング（30-60分）\n・解決策のご提案\n・概算見積もりのご提示\n・今後の進め方のご相談\n\n【相談方法】\n・オンライン面談（Zoom, Teams等）\n・訪問面談（首都圏エリア）\n・メール・チャットでの相談',
+      'まずはお気軽にご相談ください。いつ頃のご相談をご希望でしょうか？オンライン・対面どちらをご希望ですか？'
+    ]
+  };
+
+  // 初回アクセス時の段階的表示
+  useEffect(() => {
+    // 0.5秒後にボットの挨拶メッセージを表示
+    setTimeout(() => {
+      const welcomeMessage: Message = {
+        id: 1,
+        text: 'こんにちは！お問い合わせありがとうございます。どのようなご用件でしょうか？',
+        sender: 'bot',
+        timestamp: new Date()
+      };
+      setMessages([welcomeMessage]);
+      setIsLoading(false);
+      
+      // さらに0.2秒後にカテゴリー選択を表示
+      setTimeout(() => {
+        setShowCategorySelector(true);
+      }, 200);
+    }, 500);
+  }, []);
+
+  const handleCategorySelect = (category: string) => {
+    setSelectedCategory(category);
+    setShowCategorySelector(false);
+    
+    // カテゴリー選択のメッセージを追加
+    const userMessage: Message = {
+      id: messages.length + 1,
+      text: `「${categoryNames[category]}」について聞きたい`,
+      sender: 'user',
+      timestamp: new Date(),
+      category
+    };
+    
+    setMessages(prev => [...prev, userMessage]);
+    
+    // ボットの応答を段階的に追加
+    const responses = categoryResponses[category];
+    let messageId = messages.length + 2;
+    
+    // 最初の応答（1秒後）
+    setIsLoading(true);
+    setTimeout(() => {
+      const firstMessage: Message = {
+        id: messageId++,
+        text: responses[0],
+        sender: 'bot',
+        timestamp: new Date()
+      };
+      setMessages(prev => [...prev, firstMessage]);
+      setIsLoading(false);
+      
+      // 詳細説明（さらに1.5秒後）
+      setIsLoading(true);
+      setTimeout(() => {
+        const detailMessage: Message = {
+          id: messageId++,
+          text: responses[1],
+          sender: 'bot',
+          timestamp: new Date()
+        };
+        setMessages(prev => [...prev, detailMessage]);
+        setIsLoading(false);
+        
+        // 質問（さらに1秒後）
+        setIsLoading(true);
+        setTimeout(() => {
+          const questionMessage: Message = {
+            id: messageId++,
+            text: responses[2],
+            sender: 'bot',
+            timestamp: new Date()
+          };
+          setMessages(prev => [...prev, questionMessage]);
+          setIsLoading(false);
+        }, 1000);
+      }, 1500);
+    }, 1000);
+  };
+
+  const handleSendMessage = () => {
+    if (!inputMessage.trim()) return;
+
+    const userMessage: Message = {
+      id: messages.length + 1,
+      text: inputMessage,
+      sender: 'user',
+      timestamp: new Date()
+    };
+
+    setMessages(prev => [...prev, userMessage]);
+    setInputMessage('');
+    setIsLoading(true);
+
+    // AI応答を生成
+    setTimeout(() => {
+      // 知識ベースを使用してAI応答を生成
+      const response = selectedCategory 
+        ? generateAIResponse(inputMessage, selectedCategory, messageCount)
+        : { message: 'ご質問ありがとうございます。詳しくお答えさせていただきます。', showForm: false };
+      
+      const botMessage: Message = {
+        id: messages.length + 2,
+        text: response.message,
+        sender: 'bot',
+        timestamp: new Date()
+      };
+      setMessages(prev => [...prev, botMessage]);
+      setIsLoading(false);
+      setMessageCount(prev => prev + 1);
+      
+      // 依頼フォームを表示するか判定
+      if (response.showForm) {
+        setTimeout(() => {
+          setShowContactForm(true);
+        }, 500);
+      }
+    }, 1500);
+  };
+
+  const handleContactSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    // バリデーション
+    const errors = {
+      name: '',
+      company: '',
+      email: '',
+      message: ''
+    };
+    
+    if (!contactForm.name.trim()) {
+      errors.name = 'お名前を入力してください';
+    }
+    if (!contactForm.company.trim()) {
+      errors.company = '会社名を入力してください';
+    }
+    if (!contactForm.email.trim()) {
+      errors.email = 'メールアドレスを入力してください';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(contactForm.email)) {
+      errors.email = '正しいメールアドレスを入力してください';
+    }
+    if (!contactForm.message.trim()) {
+      errors.message = 'ご相談内容を入力してください';
+    }
+    
+    // エラーがある場合は処理を中断
+    if (errors.name || errors.company || errors.email || errors.message) {
+      setFormErrors(errors);
+      return;
+    }
+    
+    // エラーをクリア
+    setFormErrors({ name: '', company: '', email: '', message: '' });
+    
+    // フォームを非表示
+    setShowContactForm(false);
+    
+    // 送信完了メッセージを表示
+    const thankYouMessage: Message = {
+      id: messages.length + 1,
+      text: `ご依頼ありがとうございます。
+
+【受付完了】
+お名前：${contactForm.name}様
+会社名：${contactForm.company}
+メール：${contactForm.email}
+
+2営業日以内に、ご指定のメールアドレス宛に
+担当者よりご連絡させていただきます。
+
+今後ともDataPro Solutionsをよろしくお願いいたします。`,
+      sender: 'bot',
+      timestamp: new Date()
+    };
+    setMessages(prev => [...prev, thankYouMessage]);
+    
+    // フォームをリセット
+    setContactForm({
+      name: '',
+      company: '',
+      email: '',
+      phone: '',
+      message: ''
+    });
+  };
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      height: '100vh',
+      backgroundColor: '#f9fafb'
+    }}>
+      {/* ヘッダー */}
+      <div style={{
+        backgroundColor: 'white',
+        borderBottom: '1px solid #e5e7eb',
+        padding: '1rem',
+        boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)'
+      }}>
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.75rem',
+          maxWidth: '48rem',
+          margin: '0 auto'
+        }}>
+          <MessageCircle size={24} color="#2563eb" />
+          <div>
+            <h2 style={{
+              fontSize: '1.125rem',
+              fontWeight: '600',
+              color: '#1f2937',
+              margin: 0
+            }}>
+              カスタマーサポート
+            </h2>
+            <p style={{
+              fontSize: '0.75rem',
+              color: '#6b7280',
+              margin: 0
+            }}>
+              マーケティング×システムのプロ集団がサポートします
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* メッセージエリア */}
+      <div style={{
+        flex: 1,
+        overflowY: 'auto',
+        padding: '1rem'
+      }}>
+        <div style={{
+          maxWidth: '48rem',
+          margin: '0 auto'
+        }}>
+          {/* メッセージ表示 */}
+          {messages.map(message => (
+            <div
+              key={message.id}
+              style={{
+                display: 'flex',
+                justifyContent: message.sender === 'user' ? 'flex-end' : 'flex-start',
+                marginBottom: '1rem'
+              }}
+            >
+              <div style={{
+                maxWidth: '70%',
+                padding: '0.75rem 1rem',
+                borderRadius: '0.75rem',
+                backgroundColor: message.sender === 'user' ? '#2563eb' : 'white',
+                color: message.sender === 'user' ? 'white' : '#1f2937',
+                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)'
+              }}>
+                {message.category && message.sender === 'user' && (
+                  <div style={{
+                    fontSize: '0.75rem',
+                    opacity: 0.8,
+                    marginBottom: '0.25rem'
+                  }}>
+                    📁 カテゴリー選択
+                  </div>
+                )}
+                <div style={{ whiteSpace: 'pre-wrap' }}>{message.text}</div>
+                <div style={{
+                  fontSize: '0.75rem',
+                  opacity: 0.7,
+                  marginTop: '0.25rem'
+                }}>
+                  {message.timestamp.toLocaleTimeString('ja-JP', {
+                    hour: '2-digit',
+                    minute: '2-digit'
+                  })}
+                </div>
+              </div>
+            </div>
+          ))}
+
+          {/* ローディング表示 */}
+          {isLoading && (
+            <div style={{
+              display: 'flex',
+              justifyContent: 'flex-start',
+              marginBottom: '1rem'
+            }}>
+              <div style={{
+                padding: '0.75rem 1rem',
+                borderRadius: '0.75rem',
+                backgroundColor: 'white',
+                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)'
+              }}>
+                <div style={{ display: 'flex', gap: '0.25rem' }}>
+                  <span style={{ animation: 'bounce 1.4s infinite ease-in-out' }}>●</span>
+                  <span style={{ animation: 'bounce 1.4s infinite ease-in-out 0.2s' }}>●</span>
+                  <span style={{ animation: 'bounce 1.4s infinite ease-in-out 0.4s' }}>●</span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* カテゴリー選択 */}
+          {showCategorySelector && !selectedCategory && (
+            <div style={{ 
+              animation: 'fadeIn 0.3s ease-in',
+              opacity: 1
+            }}>
+              <CategorySelector onSelect={handleCategorySelect} />
+            </div>
+          )}
+          
+          {/* 依頼フォーム */}
+          {showContactForm && (
+            <div style={{
+              animation: 'fadeIn 0.3s ease-in',
+              backgroundColor: 'white',
+              borderRadius: '0.75rem',
+              padding: '1.5rem',
+              marginTop: '1rem',
+              boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)'
+            }}>
+              <h3 style={{ 
+                fontSize: '1.1rem', 
+                fontWeight: 'bold',
+                marginBottom: '0.5rem',
+                color: '#1f2937'
+              }}>
+                無料診断のお申し込み
+              </h3>
+              <p style={{
+                fontSize: '0.75rem',
+                color: '#ef4444',
+                marginBottom: '1rem'
+              }}>
+                <span style={{ color: '#ef4444' }}>*</span> は必須入力項目です
+              </p>
+              <form onSubmit={handleContactSubmit}>
+                <div style={{ marginBottom: '1rem' }}>
+                  <label style={{ 
+                    display: 'flex', 
+                    alignItems: 'center',
+                    gap: '0.5rem',
+                    fontSize: '0.875rem',
+                    fontWeight: '500',
+                    color: '#374151',
+                    marginBottom: '0.25rem'
+                  }}>
+                    <User size={16} />
+                    お名前 <span style={{ color: '#ef4444' }}>*</span>
+                  </label>
+                  <input
+                    type="text"
+                    required
+                    value={contactForm.name}
+                    onChange={(e) => setContactForm({...contactForm, name: e.target.value})}
+                    style={{
+                      width: '100%',
+                      padding: '0.5rem',
+                      border: '1px solid #d1d5db',
+                      borderRadius: '0.375rem',
+                      fontSize: '0.875rem'
+                    }}
+                    placeholder="山田 太郎"
+                  />
+                  {formErrors.name && (
+                    <span style={{
+                      fontSize: '0.75rem',
+                      color: '#ef4444',
+                      marginTop: '0.25rem',
+                      display: 'block'
+                    }}>
+                      {formErrors.name}
+                    </span>
+                  )}
+                </div>
+                
+                <div style={{ marginBottom: '1rem' }}>
+                  <label style={{ 
+                    display: 'flex', 
+                    alignItems: 'center',
+                    gap: '0.5rem',
+                    fontSize: '0.875rem',
+                    fontWeight: '500',
+                    color: '#374151',
+                    marginBottom: '0.25rem'
+                  }}>
+                    <Building size={16} />
+                    会社名 <span style={{ color: '#ef4444' }}>*</span>
+                  </label>
+                  <input
+                    type="text"
+                    required
+                    value={contactForm.company}
+                    onChange={(e) => setContactForm({...contactForm, company: e.target.value})}
+                    style={{
+                      width: '100%',
+                      padding: '0.5rem',
+                      border: '1px solid #d1d5db',
+                      borderRadius: '0.375rem',
+                      fontSize: '0.875rem'
+                    }}
+                    placeholder="株式会社サンプル"
+                  />
+                  {formErrors.company && (
+                    <span style={{
+                      fontSize: '0.75rem',
+                      color: '#ef4444',
+                      marginTop: '0.25rem',
+                      display: 'block'
+                    }}>
+                      {formErrors.company}
+                    </span>
+                  )}
+                </div>
+                
+                <div style={{ marginBottom: '1rem' }}>
+                  <label style={{ 
+                    display: 'flex', 
+                    alignItems: 'center',
+                    gap: '0.5rem',
+                    fontSize: '0.875rem',
+                    fontWeight: '500',
+                    color: '#374151',
+                    marginBottom: '0.25rem'
+                  }}>
+                    <Mail size={16} />
+                    メールアドレス <span style={{ color: '#ef4444' }}>*</span>
+                  </label>
+                  <input
+                    type="email"
+                    required
+                    value={contactForm.email}
+                    onChange={(e) => setContactForm({...contactForm, email: e.target.value})}
+                    style={{
+                      width: '100%',
+                      padding: '0.5rem',
+                      border: '1px solid #d1d5db',
+                      borderRadius: '0.375rem',
+                      fontSize: '0.875rem'
+                    }}
+                    placeholder="sample@example.com"
+                  />
+                  {formErrors.email && (
+                    <span style={{
+                      fontSize: '0.75rem',
+                      color: '#ef4444',
+                      marginTop: '0.25rem',
+                      display: 'block'
+                    }}>
+                      {formErrors.email}
+                    </span>
+                  )}
+                </div>
+                
+                <div style={{ marginBottom: '1rem' }}>
+                  <label style={{ 
+                    display: 'flex', 
+                    alignItems: 'center',
+                    gap: '0.5rem',
+                    fontSize: '0.875rem',
+                    fontWeight: '500',
+                    color: '#374151',
+                    marginBottom: '0.25rem'
+                  }}>
+                    <Phone size={16} />
+                    電話番号
+                  </label>
+                  <input
+                    type="tel"
+                    value={contactForm.phone}
+                    onChange={(e) => setContactForm({...contactForm, phone: e.target.value})}
+                    style={{
+                      width: '100%',
+                      padding: '0.5rem',
+                      border: '1px solid #d1d5db',
+                      borderRadius: '0.375rem',
+                      fontSize: '0.875rem'
+                    }}
+                    placeholder="03-1234-5678"
+                  />
+                </div>
+                
+                <div style={{ marginBottom: '1rem' }}>
+                  <label style={{ 
+                    fontSize: '0.875rem',
+                    fontWeight: '500',
+                    color: '#374151',
+                    marginBottom: '0.25rem',
+                    display: 'block'
+                  }}>
+                    ご相談内容 <span style={{ color: '#ef4444' }}>*</span>
+                  </label>
+                  <textarea
+                    required
+                    value={contactForm.message}
+                    onChange={(e) => setContactForm({...contactForm, message: e.target.value})}
+                    style={{
+                      width: '100%',
+                      padding: '0.5rem',
+                      border: '1px solid #d1d5db',
+                      borderRadius: '0.375rem',
+                      fontSize: '0.875rem',
+                      minHeight: '80px',
+                      resize: 'vertical'
+                    }}
+                    placeholder="具体的なご相談内容をお聞かせください"
+                  />
+                  {formErrors.message && (
+                    <span style={{
+                      fontSize: '0.75rem',
+                      color: '#ef4444',
+                      marginTop: '0.25rem',
+                      display: 'block'
+                    }}>
+                      {formErrors.message}
+                    </span>
+                  )}
+                </div>
+                
+                <button
+                  type="submit"
+                  style={{
+                    width: '100%',
+                    padding: '0.75rem',
+                    backgroundColor: '#2563eb',
+                    color: 'white',
+                    border: 'none',
+                    borderRadius: '0.375rem',
+                    fontSize: '0.875rem',
+                    fontWeight: '500',
+                    cursor: 'pointer',
+                    transition: 'background-color 0.2s'
+                  }}
+                  onMouseOver={(e) => e.currentTarget.style.backgroundColor = '#1d4ed8'}
+                  onMouseOut={(e) => e.currentTarget.style.backgroundColor = '#2563eb'}
+                >
+                  無料診断を申し込む
+                </button>
+              </form>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 入力エリア */}
+      <div style={{
+        backgroundColor: 'white',
+        borderTop: '1px solid #e5e7eb',
+        padding: '1rem'
+      }}>
+        <div style={{
+          maxWidth: '48rem',
+          margin: '0 auto',
+          display: 'flex',
+          gap: '0.75rem'
+        }}>
+          <input
+            type="text"
+            value={inputMessage}
+            onChange={(e) => setInputMessage(e.target.value)}
+            onKeyPress={(e) => e.key === 'Enter' && handleSendMessage()}
+            placeholder={selectedCategory ? "メッセージを入力..." : "まずはカテゴリーをお選びください"}
+            disabled={!selectedCategory}
+            style={{
+              flex: 1,
+              padding: '0.75rem',
+              borderRadius: '0.5rem',
+              border: '1px solid #e5e7eb',
+              fontSize: '0.875rem',
+              outline: 'none',
+              opacity: selectedCategory ? 1 : 0.5
+            }}
+          />
+          <button
+            onClick={handleSendMessage}
+            disabled={!inputMessage.trim() || !selectedCategory}
+            style={{
+              padding: '0.75rem 1.5rem',
+              backgroundColor: inputMessage.trim() && selectedCategory ? '#2563eb' : '#e5e7eb',
+              color: inputMessage.trim() && selectedCategory ? 'white' : '#9ca3af',
+              borderRadius: '0.5rem',
+              border: 'none',
+              cursor: inputMessage.trim() && selectedCategory ? 'pointer' : 'not-allowed',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+              transition: 'all 0.2s'
+            }}
+          >
+            <Send size={18} />
+            送信
+          </button>
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes bounce {
+          0%, 60%, 100% {
+            transform: translateY(0);
+          }
+          30% {
+            transform: translateY(-10px);
+          }
+        }
+        @keyframes fadeIn {
+          from {
+            opacity: 0;
+            transform: translateY(10px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default NewCustomerChat;

--- a/frontend/src/companyKnowledge.ts
+++ b/frontend/src/companyKnowledge.ts
@@ -1,0 +1,329 @@
+// 会社の知識ベース
+export const companyKnowledge = {
+  // 会社基本情報
+  companyInfo: {
+    name: "DataPro Solutions株式会社",
+    established: "2016年",
+    employees: "80名（エンジニア40名以上）",
+    location: "東京都渋谷区",
+    mission: "AIとデータの力で、マーケティングの新たな価値を創造する",
+    vision: "デジタル時代のマーケティング変革をリードする",
+    culture: [
+      "フラットな組織体制",
+      "迅速な意思決定",
+      "挑戦を評価する文化",
+      "継続的な学習と成長を重視"
+    ]
+  },
+
+  // サービス詳細
+  services: {
+    marketing: {
+      overview: "AIを活用したデータドリブンマーケティングの実現",
+      capabilities: [
+        "マーケティングDXコンサルティング",
+        "CDP（カスタマーデータプラットフォーム）構築・分析",
+        "MA/CRM導入・改善支援",
+        "Web広告運用・最適化（Google, Facebook, Instagram, Twitter）",
+        "SEO/コンテンツマーケティング戦略",
+        "ECサイト運営支援（Shopify Plus パートナー）",
+        "クリエイティブ制作・UI/UX設計"
+      ],
+      tools: [
+        "Google Analytics 4",
+        "BigQuery",
+        "Google Tag Manager",
+        "Salesforce",
+        "HubSpot",
+        "Marketo",
+        "SendGrid"
+      ],
+      pricing: {
+        consulting: "月額50万円〜",
+        operation: "月額30万円〜（広告費別）",
+        setup: "初期費用100万円〜",
+        customPlatform: "300万円〜（カスタムプラットフォーム構築）"
+      }
+    },
+    
+    development: {
+      overview: "クラウドネイティブな高速・低コストのソリューション開発",
+      technologies: {
+        frontend: ["React", "Vue.js", "Next.js", "TypeScript", "Tailwind CSS"],
+        backend: ["Python", "Django", "FastAPI", "Node.js", "Go"],
+        mobile: ["React Native", "Flutter", "PWA"],
+        cloud: ["Google Cloud Platform（主力）", "AWS", "Docker", "Cloud Run", "App Engine"],
+        database: ["MySQL", "Cloud Datastore", "BigQuery", "PostgreSQL", "Redis"],
+        ai: ["OpenAI API", "Claude API", "Vertex AI", "独自ML モデル"],
+        devOps: ["GitHub Actions", "Cloud Build", "Terraform", "Monitoring（Cloud Monitoring）"]
+      },
+      projectTypes: [
+        "マーケティングプラットフォーム開発",
+        "CDP（顧客データ基盤）構築",
+        "ECサイト構築・最適化",
+        "AIを活用した分析ダッシュボード",
+        "MA/CRM カスタマイズ開発",
+        "データパイプライン構築",
+        "リアルタイム分析システム"
+      ],
+      timeline: {
+        small: "1-2ヶ月（簡易的なWebサイト・LP）",
+        medium: "3-6ヶ月（業務システム・ECサイト）",
+        large: "6ヶ月以上（大規模プラットフォーム）"
+      }
+    },
+
+    consulting: {
+      overview: "マーケティングDXを中心とした包括的な変革支援",
+      areas: [
+        "マーケティングDX戦略立案",
+        "データドリブン経営への転換支援",
+        "CDP導入・データ統合戦略",
+        "MA/CRM最適化コンサルティング",
+        "AI活用による業務自動化",
+        "組織のデジタル人材育成"
+      ]
+    },
+    
+    products: {
+      dataPlatform: {
+        name: "DataConnect Platform",
+        description: "顧客データを統合・分析し、マーケティングを最適化するプラットフォーム",
+        features: [
+          "マルチチャネルデータ統合",
+          "リアルタイム顧客セグメンテーション",
+          "AI による行動予測",
+          "自動レポーティング",
+          "APIによる外部連携"
+        ]
+      },
+      analyticsTools: {
+        name: "Marketing Analytics Suite",
+        description: "AIを活用した高度なマーケティング分析ツール",
+        features: [
+          "クロスチャネル分析",
+          "カスタマージャーニー可視化",
+          "ROI自動計算",
+          "予測分析"
+        ]
+      }
+    }
+  },
+
+  // 実績・事例
+  caseStudies: [
+    {
+      industry: "小売業",
+      client: "大手アパレルブランドA社",
+      challenge: "ECサイトの売上が伸び悩んでいた",
+      solution: "UI/UX改善とレコメンドエンジン導入",
+      result: "CVR 200%向上、月商3億円達成",
+      technologies: ["React", "Node.js", "AWS", "機械学習"]
+    },
+    {
+      industry: "製造業",
+      client: "中堅製造業B社",
+      challenge: "在庫管理と生産計画の非効率",
+      solution: "リアルタイム在庫管理システム構築",
+      result: "在庫回転率30%改善、欠品率80%削減",
+      technologies: ["Ruby on Rails", "PostgreSQL", "Docker"]
+    },
+    {
+      industry: "サービス業",
+      client: "人材サービスC社",
+      challenge: "問い合わせ対応の人手不足",
+      solution: "AIチャットボット導入",
+      result: "問い合わせ対応の80%を自動化",
+      technologies: ["Python", "Claude API", "React"]
+    }
+  ],
+
+  // 強み・差別化ポイント
+  strengths: [
+    "マーケティングとエンジニアリングの両方に精通",
+    "ワンストップでの対応が可能",
+    "最新のAI技術を活用した効率的なソリューション",
+    "アジャイル開発による柔軟な対応",
+    "専任PMによる密なコミュニケーション",
+    "業界特化型のノウハウ蓄積"
+  ],
+
+  // FAQ
+  faq: {
+    development: {
+      "既存システムとの連携は可能ですか？": "はい、APIやデータベース連携など、様々な方法で既存システムとの連携が可能です。",
+      "保守運用もお願いできますか？": "もちろんです。24時間365日の監視体制や定期メンテナンスなど、ご要望に応じた保守プランをご提供します。",
+      "開発中の仕様変更は可能ですか？": "アジャイル開発を採用しているため、柔軟に対応可能です。ただし、大きな変更は追加費用が発生する場合があります。"
+    },
+    marketing: {
+      "効果測定はどのように行いますか？": "KPIを明確に設定し、Google AnalyticsやMA ツールを使用して定量的に測定します。月次レポートで詳細をご報告します。",
+      "広告予算はどれくらい必要ですか？": "業界や目標により異なりますが、一般的には月額30万円以上を推奨しています。",
+      "BtoBマーケティングも対応可能ですか？": "はい、BtoB企業様の実績も多数ございます。リード獲得からナーチャリングまで一貫してサポートします。"
+    },
+    general: {
+      "地方企業でも対応可能ですか？": "もちろんです。オンラインでの打ち合わせやリモート開発により、全国対応しております。",
+      "予算が限られていますが相談できますか？": "ご予算に応じた最適なプランをご提案します。段階的な導入も可能です。",
+      "契約期間の縛りはありますか？": "プロジェクトにより異なりますが、最短3ヶ月から対応可能です。"
+    }
+  }
+};
+
+// コンテキストから適切な情報を検索する関数
+export function searchKnowledge(query: string): string {
+  const lowerQuery = query.toLowerCase();
+  let relevantInfo: string[] = [];
+
+  // キーワードマッチングによる関連情報の抽出
+  if (lowerQuery.includes('料金') || lowerQuery.includes('費用') || lowerQuery.includes('価格')) {
+    relevantInfo.push(`マーケティング支援: ${companyKnowledge.services.marketing.pricing.consulting}`);
+    relevantInfo.push(`広告運用: ${companyKnowledge.services.marketing.pricing.operation}`);
+    relevantInfo.push('システム開発: プロジェクト規模により個別見積もり');
+  }
+
+  if (lowerQuery.includes('期間') || lowerQuery.includes('納期') || lowerQuery.includes('スケジュール')) {
+    relevantInfo.push(`小規模: ${companyKnowledge.services.development.timeline.small}`);
+    relevantInfo.push(`中規模: ${companyKnowledge.services.development.timeline.medium}`);
+    relevantInfo.push(`大規模: ${companyKnowledge.services.development.timeline.large}`);
+  }
+
+  if (lowerQuery.includes('技術') || lowerQuery.includes('言語') || lowerQuery.includes('フレームワーク')) {
+    relevantInfo.push('対応技術スタック:');
+    relevantInfo.push(`フロントエンド: ${companyKnowledge.services.development.technologies.frontend.join(', ')}`);
+    relevantInfo.push(`バックエンド: ${companyKnowledge.services.development.technologies.backend.join(', ')}`);
+  }
+
+  if (lowerQuery.includes('事例') || lowerQuery.includes('実績')) {
+    companyKnowledge.caseStudies.forEach(study => {
+      relevantInfo.push(`${study.industry} - ${study.client}: ${study.result}`);
+    });
+  }
+
+  return relevantInfo.join('\n');
+}
+
+// AI応答を生成する関数
+// ユーザーの課題に対して具体的な解決策を提案
+// messageCountを追加して会話の流れを管理
+export function generateAIResponse(userMessage: string, category: string, messageCount: number = 0): { message: string, showForm?: boolean } {
+  const knowledge = searchKnowledge(userMessage);
+  const lowerMessage = userMessage.toLowerCase();
+
+  // 初回の課題入力時（カテゴリー選択後の最初の質問）
+  if (messageCount === 0) {
+    // 具体的な課題に対する提案
+    if (lowerMessage.includes('営業') || lowerMessage.includes('リード') || lowerMessage.includes('新規顧客')) {
+      return {
+        message: `ご質問ありがとうございます。
+
+営業・リード獲得の課題、非常によく理解できます。
+弊社では以下のようなソリューションをご提供しています：
+
+📊 **データドリブン営業支援**
+・リード獲得チャネルの最適化
+・スコアリングによるリードの質向上
+・MAツールでのナーチャリング自動化
+
+🎯 **実績**
+同業他社ではリード獲得数を月間5件から50件に増加、
+商談化率も150%向上した実績がございます。
+
+詳しいプランをご提案させていただきたいのですが、
+まずは無料診断で現状をお伺いできませんか？`,
+        showForm: true
+      };
+    }
+
+    if (lowerMessage.includes('ec') || lowerMessage.includes('ネットショップ') || lowerMessage.includes('通販')) {
+      return {
+        message: `ご質問ありがとうございます。
+
+ECサイトの課題ですね。弊社のShopify Plusパートナーとしての
+実績を活かし、以下のソリューションをご提案いたします：
+
+🛒 **ECサイト最適化**
+・UI/UX改善によるCVR向上
+・AIレコメンドエンジン
+・カート放棄対策
+・リピーター育成プログラム
+
+📈 **成果事例**
+中堅EC事業者様でカート放棄率65%改善、
+リピート率200%向上を実現しました。
+
+貴社のECサイトの具体的な課題をお伺いし、
+最適なプランをご提案いたします。`,
+        showForm: true
+      };
+    }
+
+    if (lowerMessage.includes('マーケティング') || lowerMessage.includes('広告') || lowerMessage.includes('集客')) {
+      return {
+        message: `ご質問ありがとうございます。
+
+マーケティングの課題ですね。AIを活用した
+データドリブンマーケティングで解決いたします：
+
+🎯 **マーケティングDXソリューション**
+・CDP構築による顧客データ統合
+・AIを活用した広告最適化
+・MA/CRM導入・最適化
+・コンテンツマーケティング
+
+📊 **実績**
+大手不動産会社様でマーケティングROI 320%向上、
+リード獲得コスト40%削減を達成しました。
+
+まずは現状のマーケティング課題をお聞かせください。
+無料診断で最適な改善プランをご提案いたします。`,
+        showForm: true
+      };
+    }
+
+    if (lowerMessage.includes('ai') || lowerMessage.includes('チャットボット') || lowerMessage.includes('自動')) {
+      return {
+        message: `ご質問ありがとうございます。
+
+AI活用のご検討ですね。最新のAI技術で
+業務効率化を実現します：
+
+🤖 **AIソリューション**
+・AIチャットボット（問い合わせ自動化）
+・予測分析・需要予測
+・自動コンテンツ生成
+・データ分析・インサイト抽出
+
+🎯 **導入事例**
+人材サービス企業様で問い合わせ対応の80%を自動化、
+オペレーターコストを年間2,000万円削減しました。
+
+どのような業務へのAI活用をお考えでしょうか？
+詳しくお聞かせください。`,
+        showForm: true
+      };
+    }
+
+    // その他の一般的な課題
+    return {
+      message: `ご質問ありがとうございます。
+
+お客様の課題に対して、弊社では以下のような
+ソリューションをご提供しています：
+
+${knowledge}
+
+詳しいプランをご提案させていただきたいので、
+まずは無料診断でお話をお伺いできませんか？`,
+      showForm: true
+    };
+  }
+  
+  // 2回目以降の返信（通常の会話継続）
+  return {
+    message: `承知いたしました。
+
+${knowledge}
+
+ご不明な点がございましたら、お気軽にお尋ねください。`,
+    showForm: false
+  };
+}


### PR DESCRIPTION
入力フォームの実装まで。
次は以下を実装する。

新規の場合：カテゴリを選択したら、具体的なサービス概要と事例を3つぐらいシンプルに返答。その後に入力フォームを表示する。入力フォーム送信後人間にエスカレーションする。その場で返信するか、2営業日以内に返信するかを人間が選択する。2営業日以内を選択した場合、定型分をチャットで返すようにする。