### PR TITLE
feat: チャット履歴機能の実装

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
         end
         member do
           post :escalate
+          post :resume
         end
       end
       resources :users, only: %i[show update]

--- a/db/migrate/20250830135036_add_status_to_conversations.rb
+++ b/db/migrate/20250830135036_add_status_to_conversations.rb
@@ -1,0 +1,6 @@
+class AddStatusToConversations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :conversations, :status, :string, default: 'active', null: false
+    add_index :conversations, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_24_131320) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_30_135036) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "vector"
@@ -44,7 +44,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_24_131320) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "metadata"
+    t.string "status", default: "active", null: false
     t.index ["session_id"], name: "index_conversations_on_session_id", unique: true
+    t.index ["status"], name: "index_conversations_on_status"
     t.index ["user_id"], name: "index_conversations_on_user_id"
   end
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,9 @@
       "devDependencies": {
         "@eslint/js": "^9.33.0",
         "@tailwindcss/postcss": "^4.1.12",
+        "@testing-library/jest-dom": "^6.8.0",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -34,6 +37,13 @@
         "vite": "^7.1.2",
         "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -294,6 +304,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1683,6 +1703,104 @@
         "tailwindcss": "4.1.12"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
+      "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2265,6 +2383,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2287,6 +2416,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2553,6 +2692,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -2595,6 +2741,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2604,6 +2760,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.211",
@@ -3169,6 +3333,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3598,6 +3772,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.18",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
@@ -3630,6 +3815,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -3910,6 +4105,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3962,6 +4187,14 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4008,6 +4241,20 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve-from": {
@@ -4185,6 +4432,19 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,9 @@
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@tailwindcss/postcss": "^4.1.12",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/frontend/src/components/ChatHistory.tsx
+++ b/frontend/src/components/ChatHistory.tsx
@@ -1,0 +1,211 @@
+import React, { useState, useEffect } from 'react';
+import { History, X, MessageCircle, Calendar, ChevronRight } from 'lucide-react';
+
+interface Message {
+  id: number;
+  content: string;
+  role: 'user' | 'assistant' | 'system' | 'company';
+  created_at: string;
+}
+
+interface Conversation {
+  id: string;
+  session_id: string;
+  status: 'active' | 'inactive';
+  created_at: string;
+  updated_at: string;
+  messages: Message[];
+}
+
+interface ChatHistoryProps {
+  onResumeConversation?: (conversationId: string) => void;
+}
+
+const ChatHistory: React.FC<ChatHistoryProps> = ({ onResumeConversation }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Cookieからセッション IDを取得
+  const getSessionId = () => {
+    const cookies = document.cookie.split(';');
+    for (const cookie of cookies) {
+      const [key, value] = cookie.trim().split('=');
+      if (key === 'session_id') {
+        return value;
+      }
+    }
+    return null;
+  };
+
+  // 会話履歴を取得
+  const fetchConversations = async () => {
+    setLoading(true);
+    setError(null);
+    
+    try {
+      const sessionId = getSessionId();
+      const headers: HeadersInit = {
+        'Content-Type': 'application/json',
+      };
+      
+      if (sessionId) {
+        headers['X-Session-Id'] = sessionId;
+      }
+
+      const response = await fetch('http://localhost:3000/api/v1/conversations', {
+        method: 'GET',
+        headers,
+        credentials: 'include'
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch conversations');
+      }
+
+      const data = await response.json();
+      setConversations(data.conversations || []);
+    } catch (err) {
+      setError('履歴の取得に失敗しました');
+      console.error('Error fetching conversations:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // モーダルを開いた時に履歴を取得
+  useEffect(() => {
+    if (isOpen) {
+      fetchConversations();
+    }
+  }, [isOpen]);
+
+  // 会話を再開
+  const handleResumeConversation = (conversationId: string) => {
+    if (onResumeConversation) {
+      onResumeConversation(conversationId);
+    }
+    setIsOpen(false);
+  };
+
+  // 日付フォーマット
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+  // 会話のプレビューテキストを取得
+  const getPreviewText = (conversation: Conversation) => {
+    if (conversation.messages.length === 0) {
+      return 'メッセージはありません';
+    }
+    const firstUserMessage = conversation.messages.find(m => m.role === 'user');
+    if (firstUserMessage) {
+      return firstUserMessage.content.length > 50 
+        ? firstUserMessage.content.substring(0, 50) + '...'
+        : firstUserMessage.content;
+    }
+    return conversation.messages[0].content.substring(0, 50) + '...';
+  };
+
+  return (
+    <>
+      {/* チャット履歴ボタン */}
+      <button
+        onClick={() => setIsOpen(true)}
+        className="flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+        aria-label="チャット履歴"
+      >
+        <History className="w-5 h-5" data-testid="history-icon" />
+        <span>チャット履歴</span>
+      </button>
+
+      {/* モーダル */}
+      {isOpen && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-2xl max-h-[80vh] flex flex-col">
+            {/* ヘッダー */}
+            <div className="flex justify-between items-center p-6 border-b">
+              <h2 className="text-xl font-semibold">過去のチャット</h2>
+              <button
+                onClick={() => setIsOpen(false)}
+                className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+                aria-label="閉じる"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            {/* コンテンツ */}
+            <div className="flex-1 overflow-y-auto p-6">
+              {loading && (
+                <div className="text-center py-8 text-gray-500">
+                  読み込み中...
+                </div>
+              )}
+
+              {error && (
+                <div className="text-center py-8 text-red-500">
+                  {error}
+                </div>
+              )}
+
+              {!loading && !error && conversations.length === 0 && (
+                <div className="text-center py-8 text-gray-500">
+                  チャット履歴はありません
+                </div>
+              )}
+
+              {!loading && !error && conversations.length > 0 && (
+                <div className="space-y-3">
+                  {conversations.map((conversation) => (
+                    <button
+                      key={conversation.id}
+                      onClick={() => handleResumeConversation(conversation.id)}
+                      className="w-full text-left p-4 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors group"
+                    >
+                      <div className="flex items-start justify-between">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 mb-2">
+                            <MessageCircle className="w-4 h-4 text-gray-400" />
+                            <span className="text-sm text-gray-600">
+                              {conversation.messages.length} メッセージ
+                            </span>
+                            {conversation.status === 'active' && (
+                              <span className="text-xs px-2 py-1 bg-green-100 text-green-700 rounded">
+                                アクティブ
+                              </span>
+                            )}
+                          </div>
+                          <p className="text-gray-900 mb-2">
+                            {getPreviewText(conversation)}
+                          </p>
+                          <div className="flex items-center gap-1 text-xs text-gray-500">
+                            <Calendar className="w-3 h-3" />
+                            <span>
+                              {formatDate(conversation.updated_at)}
+                            </span>
+                          </div>
+                        </div>
+                        <ChevronRight className="w-5 h-5 text-gray-400 group-hover:text-gray-600 transition-colors" />
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ChatHistory;

--- a/frontend/src/components/__tests__/ChatHistory.test.tsx
+++ b/frontend/src/components/__tests__/ChatHistory.test.tsx
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ChatHistory from '../ChatHistory';
+
+// APIモック
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const mockConversations = [
+  {
+    id: 'conv-1',
+    session_id: 'session-1',
+    status: 'active',
+    created_at: '2025-08-30T10:00:00Z',
+    updated_at: '2025-08-30T10:30:00Z',
+    messages: [
+      {
+        id: 1,
+        content: 'こんにちは',
+        role: 'user',
+        created_at: '2025-08-30T10:00:00Z'
+      },
+      {
+        id: 2,
+        content: 'お問い合わせありがとうございます',
+        role: 'assistant',
+        created_at: '2025-08-30T10:01:00Z'
+      }
+    ]
+  },
+  {
+    id: 'conv-2',
+    session_id: 'session-2',
+    status: 'inactive',
+    created_at: '2025-08-29T14:00:00Z',
+    updated_at: '2025-08-29T14:45:00Z',
+    messages: [
+      {
+        id: 3,
+        content: '料金について教えてください',
+        role: 'user',
+        created_at: '2025-08-29T14:00:00Z'
+      }
+    ]
+  }
+];
+
+describe('ChatHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('履歴ボタン', () => {
+    it('チャット履歴ボタンが表示される', () => {
+      render(<ChatHistory />);
+      const button = screen.getByRole('button', { name: /チャット履歴/i });
+      expect(button).toBeInTheDocument();
+    });
+
+    it('ボタンにアイコンが表示される', () => {
+      render(<ChatHistory />);
+      const icon = screen.getByTestId('history-icon');
+      expect(icon).toBeInTheDocument();
+    });
+
+    it('ボタンクリックで履歴一覧が開く', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ conversations: mockConversations })
+      });
+
+      render(<ChatHistory />);
+      const button = screen.getByRole('button', { name: /チャット履歴/i });
+      
+      fireEvent.click(button);
+      
+      await waitFor(() => {
+        expect(screen.getByText('過去のチャット')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('会話一覧表示', () => {
+    it('過去の会話一覧が表示される', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ conversations: mockConversations })
+      });
+
+      render(<ChatHistory />);
+      const button = screen.getByRole('button', { name: /チャット履歴/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        // 各会話の最初のメッセージが表示される
+        expect(screen.getByText('こんにちは')).toBeInTheDocument();
+        expect(screen.getByText('料金について教えてください')).toBeInTheDocument();
+      });
+    });
+
+    it('会話の日時が表示される', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ conversations: mockConversations })
+      });
+
+      render(<ChatHistory />);
+      const button = screen.getByRole('button', { name: /チャット履歴/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        // 日付フォーマットが表示されることを確認（複数あるので最初のものを確認）
+        const dateElements = screen.getAllByText(/2025/);
+        expect(dateElements.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('会話がない場合はメッセージが表示される', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ conversations: [] })
+      });
+
+      render(<ChatHistory />);
+      const button = screen.getByRole('button', { name: /チャット履歴/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByText('チャット履歴はありません')).toBeInTheDocument();
+      });
+    });
+
+    it('読み込み中の表示', async () => {
+      mockFetch.mockImplementation(() => new Promise(() => {})); // 永遠にpending
+
+      render(<ChatHistory />);
+      const button = screen.getByRole('button', { name: /チャット履歴/i });
+      fireEvent.click(button);
+
+      expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    });
+
+    it('エラー時の表示', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      render(<ChatHistory />);
+      const button = screen.getByRole('button', { name: /チャット履歴/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByText('履歴の取得に失敗しました')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('会話の再開', () => {
+    it('会話をクリックすると再開される', async () => {
+      const onResumeConversation = vi.fn();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ conversations: mockConversations })
+      });
+
+      render(<ChatHistory onResumeConversation={onResumeConversation} />);
+      const button = screen.getByRole('button', { name: /チャット履歴/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        const conversation = screen.getByText('こんにちは').closest('button');
+        fireEvent.click(conversation!);
+      });
+
+      expect(onResumeConversation).toHaveBeenCalledWith('conv-1');
+    });
+
+    it('会話再開後に履歴モーダルが閉じる', async () => {
+      const onResumeConversation = vi.fn();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ conversations: mockConversations })
+      });
+
+      render(<ChatHistory onResumeConversation={onResumeConversation} />);
+      const button = screen.getByRole('button', { name: /チャット履歴/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        const conversation = screen.getByText('こんにちは').closest('button');
+        fireEvent.click(conversation!);
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('過去のチャット')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('API連携', () => {
+    it('正しいAPIエンドポイントを呼び出す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ conversations: [] })
+      });
+
+      render(<ChatHistory />);
+      const button = screen.getByRole('button', { name: /チャット履歴/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/api/v1/conversations'),
+          expect.objectContaining({
+            method: 'GET',
+            headers: expect.objectContaining({
+              'Content-Type': 'application/json'
+            })
+          })
+        );
+      });
+    });
+
+    it('セッションIDがヘッダーに含まれる', async () => {
+      const sessionId = 'test-session-123';
+      document.cookie = `session_id=${sessionId}`;
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ conversations: [] })
+      });
+
+      render(<ChatHistory />);
+      const button = screen.getByRole('button', { name: /チャット履歴/i });
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              'X-Session-Id': sessionId
+            })
+          })
+        );
+      });
+    });
+  });
+});

--- a/spec/requests/api/v1/chat_history_spec.rb
+++ b/spec/requests/api/v1/chat_history_spec.rb
@@ -1,0 +1,191 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::ChatHistory', type: :request do
+  let(:session_id) { SecureRandom.uuid }
+  let(:headers) { { 'X-Session-Id' => session_id, 'Content-Type' => 'application/json' } }
+
+  describe 'GET /api/v1/conversations' do
+    context 'セッションIDに紐づく会話がある場合' do
+      let!(:user_conversations) do
+        3.times.map do |i|
+          conversation = create(:conversation, 
+            session_id: session_id,
+            created_at: i.days.ago,
+            updated_at: i.hours.ago
+          )
+          
+          # 各会話にメッセージを追加
+          create(:message, 
+            conversation: conversation,
+            role: 'user',
+            content: "質問#{i}"
+          )
+          create(:message,
+            conversation: conversation,
+            role: 'assistant',
+            content: "回答#{i}"
+          )
+          
+          conversation
+        end
+      end
+
+      let!(:other_conversation) do
+        # 他のセッションの会話（表示されないべき）
+        create(:conversation, session_id: SecureRandom.uuid)
+      end
+
+      it 'セッションIDに紐づく会話のみを返す' do
+        get '/api/v1/conversations', headers: headers
+        
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        
+        expect(json['conversations'].length).to eq(3)
+        conversation_ids = json['conversations'].map { |c| c['id'] }
+        expect(conversation_ids).not_to include(other_conversation.id)
+      end
+
+      it '会話は更新日時の降順で返される' do
+        get '/api/v1/conversations', headers: headers
+        
+        json = JSON.parse(response.body)
+        updated_times = json['conversations'].map { |c| Time.parse(c['updated_at']) }
+        
+        expect(updated_times).to eq(updated_times.sort.reverse)
+      end
+
+      it '各会話のメッセージが含まれる' do
+        get '/api/v1/conversations', headers: headers
+        
+        json = JSON.parse(response.body)
+        first_conversation = json['conversations'].first
+        
+        expect(first_conversation['messages']).to be_present
+        expect(first_conversation['messages'].length).to eq(2)
+        
+        messages = first_conversation['messages']
+        expect(messages.any? { |m| m['role'] == 'user' }).to be true
+        expect(messages.any? { |m| m['role'] == 'assistant' }).to be true
+      end
+    end
+
+    context 'セッションIDに紐づく会話がない場合' do
+      it '空の配列を返す' do
+        get '/api/v1/conversations', headers: headers
+        
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        
+        expect(json['conversations']).to eq([])
+      end
+    end
+
+    context 'セッションIDが提供されない場合' do
+      it '新しいセッションIDを生成して空の配列を返す' do
+        get '/api/v1/conversations', headers: headers.except('X-Session-Id')
+        
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        
+        expect(json['conversations']).to eq([])
+        expect(response.cookies['session_id']).to be_present
+      end
+    end
+
+    context 'ページネーション' do
+      before do
+        10.times do |i|
+          conversation = create(:conversation, 
+            session_id: session_id,
+            created_at: i.days.ago
+          )
+          create(:message, conversation: conversation, role: 'user')
+        end
+      end
+
+      it 'ページネーションパラメータが動作する' do
+        get '/api/v1/conversations?page=1&per_page=5', headers: headers
+        
+        json = JSON.parse(response.body)
+        expect(json['conversations'].length).to eq(5)
+        expect(json['meta']['total_count']).to eq(10)
+        expect(json['meta']['total_pages']).to eq(2)
+        expect(json['meta']['current_page']).to eq(1)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/conversations/:id' do
+    let(:conversation) { create(:conversation, session_id: session_id) }
+    let!(:messages) do
+      [
+        create(:message, conversation: conversation, role: 'user', content: 'ユーザーメッセージ'),
+        create(:message, conversation: conversation, role: 'assistant', content: 'アシスタント返信'),
+        create(:message, conversation: conversation, role: 'company', content: '企業からの返信')
+      ]
+    end
+
+    context '自分のセッションの会話の場合' do
+      it '会話の詳細を取得できる' do
+        get "/api/v1/conversations/#{conversation.id}", headers: headers
+        
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        
+        expect(json['conversation']['id']).to eq(conversation.id)
+        expect(json['conversation']['messages'].length).to eq(3)
+        
+        # 全てのロールのメッセージが含まれることを確認
+        roles = json['conversation']['messages'].map { |m| m['role'] }
+        expect(roles).to include('user', 'assistant', 'company')
+      end
+    end
+
+    context '他のセッションの会話の場合' do
+      let(:other_conversation) { create(:conversation, session_id: SecureRandom.uuid) }
+
+      it '404を返す' do
+        get "/api/v1/conversations/#{other_conversation.id}", headers: headers
+        
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'POST /api/v1/conversations/:id/resume' do
+    let(:conversation) { create(:conversation, session_id: session_id, status: 'inactive') }
+    
+    context '会話の再開' do
+      it '会話のステータスをactiveに変更する' do
+        post "/api/v1/conversations/#{conversation.id}/resume", headers: headers
+        
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        
+        expect(json['conversation']['status']).to eq('active')
+        expect(conversation.reload.status).to eq('active')
+      end
+
+      it '最終更新日時を更新する' do
+        old_updated_at = conversation.updated_at
+        
+        travel 1.minute do
+          post "/api/v1/conversations/#{conversation.id}/resume", headers: headers
+          
+          expect(conversation.reload.updated_at).to be > old_updated_at
+        end
+      end
+    end
+
+    context '他のセッションの会話の場合' do
+      let(:other_conversation) { create(:conversation, session_id: SecureRandom.uuid) }
+
+      it '404を返す' do
+        post "/api/v1/conversations/#{other_conversation.id}/resume", headers: headers
+        
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
・ チャット履歴ボタンと一覧表示コンポーネント追加
・ 会話再開機能の実装
・ セッションベースの会話管理API追加
・ conversationsテーブルにstatusカラム追加
・ フロントエンド・バックエンドのテスト実装