### PR TITLE
feat: チャットとダッシュボードの完全統合を実装

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,18 +1,18 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
-    identified_by :session_id
+    identified_by :uuid
 
     def connect
-      self.session_id = find_or_create_session_id
-      logger.add_tags 'ActionCable', session_id
+      self.uuid = find_or_create_session_id
+      logger.add_tags 'ActionCable', uuid
     end
 
     private
 
     def find_or_create_session_id
-      # 開発環境用の簡易セッションID
-      # 本番環境では適切な認証を実装する必要があります
-      cookies[:session_id] ||= SecureRandom.uuid
+      # 各接続ごとに新しいセッションIDを生成（タブごとに異なる）
+      # これにより各タブが独立した会話を持つ
+      SecureRandom.uuid
     end
   end
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,6 +1,6 @@
 class Conversation < ApplicationRecord
   # アソシエーション
-  belongs_to :user
+  belongs_to :user, optional: true  # ユーザーはオプショナル（ゲストセッション対応）
   has_many :messages, dependent: :destroy
   has_many :analyses, dependent: :destroy
 

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,13 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "http://localhost:4000"
+
+    resource "*",
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      credentials: true
+  end
+end

--- a/db/migrate/20250830151340_make_user_id_optional_in_conversations.rb
+++ b/db/migrate/20250830151340_make_user_id_optional_in_conversations.rb
@@ -1,0 +1,5 @@
+class MakeUserIdOptionalInConversations < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :conversations, :user_id, true
+  end
+end

--- a/db/migrate/20250831034657_add_guest_user_id_to_conversations.rb
+++ b/db/migrate/20250831034657_add_guest_user_id_to_conversations.rb
@@ -1,0 +1,6 @@
+class AddGuestUserIdToConversations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :conversations, :guest_user_id, :string
+    add_index :conversations, :guest_user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_30_135036) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_31_034657) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "vector"
@@ -38,13 +38,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_30_135036) do
   end
 
   create_table "conversations", force: :cascade do |t|
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
     t.string "session_id"
     t.datetime "ended_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "metadata"
     t.string "status", default: "active", null: false
+    t.string "guest_user_id"
+    t.index ["guest_user_id"], name: "index_conversations_on_guest_user_id"
     t.index ["session_id"], name: "index_conversations_on_session_id", unique: true
     t.index ["status"], name: "index_conversations_on_status"
     t.index ["user_id"], name: "index_conversations_on_user_id"

--- a/frontend/src/ChatWithSelector.tsx
+++ b/frontend/src/ChatWithSelector.tsx
@@ -1,17 +1,27 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import CustomerTypeSelector from './CustomerTypeSelector';
 import Chatbot from './Chatbot';
 import NewCustomerChat from './NewCustomerChat';
 
 const ChatWithSelector: React.FC = () => {
   const [customerType, setCustomerType] = useState<'new' | 'existing' | null>(null);
+  const [hasConversationId, setHasConversationId] = useState(false);
+
+  useEffect(() => {
+    // URLハッシュに会話IDがある場合は直接チャット画面を表示
+    const hashId = window.location.hash.replace('#', '');
+    if (hashId && /^\d+$/.test(hashId)) {
+      setHasConversationId(true);
+      setCustomerType('new'); // NewCustomerChatを使用（会話履歴表示機能があるため）
+    }
+  }, []);
 
   const handleCustomerTypeSelect = (type: 'new' | 'existing') => {
     setCustomerType(type);
   };
 
-  // 顧客タイプが選択されていない場合は選択画面を表示
-  if (!customerType) {
+  // URLに会話IDがない場合のみ、顧客タイプ選択画面を表示
+  if (!customerType && !hasConversationId) {
     return <CustomerTypeSelector onSelect={handleCustomerTypeSelect} />;
   }
 

--- a/frontend/src/components/AutoResumeChat.tsx
+++ b/frontend/src/components/AutoResumeChat.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { RefreshCw, AlertCircle } from 'lucide-react';
-import SessionManager from '../services/sessionManager';
+import sessionManager from '../services/sessionManager';
 
 interface Message {
   id: number;
@@ -34,9 +34,9 @@ const AutoResumeChat: React.FC<AutoResumeChatProps> = ({
     }
 
     // 有効なセッションがあるかチェック
-    if (!SessionManager.hasValidSession()) {
+    if (!sessionManager.hasValidSession()) {
       // 最後のアクティブな会話をチェック
-      const lastActive = SessionManager.getLastActiveConversation();
+      const lastActive = sessionManager.getLastActiveConversation();
       if (!lastActive) {
         setHasAttempted(true);
         return;
@@ -52,10 +52,10 @@ const AutoResumeChat: React.FC<AutoResumeChatProps> = ({
         return;
       }
 
-      SessionManager.setCurrentConversationId(lastActive.conversationId);
+      sessionManager.setCurrentConversationId(lastActive.conversationId);
     }
 
-    const conversationId = SessionManager.getCurrentConversationId();
+    const conversationId = sessionManager.getCurrentConversationId();
     if (!conversationId) {
       setHasAttempted(true);
       return;
@@ -65,7 +65,7 @@ const AutoResumeChat: React.FC<AutoResumeChatProps> = ({
     setError(null);
 
     try {
-      const sessionId = SessionManager.getSessionId();
+      const sessionId = sessionManager.getSessionId();
       const response = await fetch(
         `http://localhost:3000/api/v1/conversations/${conversationId}`,
         {
@@ -80,7 +80,7 @@ const AutoResumeChat: React.FC<AutoResumeChatProps> = ({
 
       if (response.status === 404) {
         // 会話が見つからない場合はセッションをクリア
-        SessionManager.clearCurrentConversationId();
+        sessionManager.clearCurrentConversationId();
         setHasAttempted(true);
         return;
       }
@@ -101,7 +101,7 @@ const AutoResumeChat: React.FC<AutoResumeChatProps> = ({
       }
 
       // 最終アクティブ情報を更新
-      SessionManager.setLastActiveConversation({
+      sessionManager.setLastActiveConversation({
         conversationId: conversation.id,
         timestamp: new Date().toISOString(),
         messageCount: conversation.messages?.length || 0

--- a/frontend/src/components/ChatHistory.tsx
+++ b/frontend/src/components/ChatHistory.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { History, X, MessageCircle, Calendar, ChevronRight } from 'lucide-react';
+import SessionManager from '../services/sessionManager';
 
 interface Message {
   id: number;
@@ -27,16 +28,9 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({ onResumeConversation }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Cookieからセッション IDを取得
-  const getSessionId = () => {
-    const cookies = document.cookie.split(';');
-    for (const cookie of cookies) {
-      const [key, value] = cookie.trim().split('=');
-      if (key === 'session_id') {
-        return value;
-      }
-    }
-    return null;
+  // SessionManagerからユーザーIDを取得（全タブの会話を表示）
+  const getUserId = () => {
+    return SessionManager.getUserId();
   };
 
   // 会話履歴を取得
@@ -45,13 +39,15 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({ onResumeConversation }) => {
     setError(null);
     
     try {
-      const sessionId = getSessionId();
+      const userId = getUserId();
       const headers: HeadersInit = {
         'Content-Type': 'application/json',
       };
       
-      if (sessionId) {
-        headers['X-Session-Id'] = sessionId;
+      if (userId) {
+        headers['X-User-Id'] = userId;
+        // 互換性のため、セッションIDも送信
+        headers['X-Session-Id'] = SessionManager.getSessionId();
       }
 
       const response = await fetch('http://localhost:3000/api/v1/conversations', {

--- a/frontend/src/services/actionCable.ts
+++ b/frontend/src/services/actionCable.ts
@@ -20,13 +20,14 @@ class ActionCableService {
 
   connect() {
     if (!this.consumer) {
+      // Cookieを含めて接続（withCredentials相当）
       this.consumer = createConsumer('ws://localhost:3000/cable');
     }
     return this.consumer;
   }
 
   subscribeToConversation(
-    conversationId: string | null,
+    conversationId: string | number | null,
     handlers: ConversationHandlers
   ) {
     this.unsubscribe();

--- a/frontend/src/services/sessionManager.ts
+++ b/frontend/src/services/sessionManager.ts
@@ -6,7 +6,8 @@ interface LastActiveConversation {
 
 class SessionManager {
   private static instance: SessionManager;
-  private sessionId: string | null = null;
+  private userId: string | null = null;
+  private tabSessionId: string | null = null;
 
   private constructor() {}
 
@@ -18,25 +19,57 @@ class SessionManager {
   }
 
   /**
-   * セッションIDを取得（なければ生成）
+   * ユーザーIDを取得（なければ生成）
+   * 全タブで共有、30日間保持
    */
-  getSessionId(): string {
+  getUserId(): string {
     // メモリにキャッシュがあればそれを返す
-    if (this.sessionId) {
-      return this.sessionId;
+    if (this.userId) {
+      return this.userId;
     }
 
     // Cookieから取得
-    const existingId = this.getCookie('session_id');
+    const existingId = this.getCookie('user_id');
     if (existingId && existingId.trim() !== '') {
-      this.sessionId = existingId;
+      this.userId = existingId;
       return existingId;
     }
 
     // 新規生成
-    this.sessionId = this.generateUUID();
-    this.setCookie('session_id', this.sessionId, 30); // 30日間有効
-    return this.sessionId;
+    this.userId = this.generateUUID();
+    this.setCookie('user_id', this.userId, 30); // 30日間有効
+    return this.userId;
+  }
+
+  /**
+   * タブセッションIDを取得（なければ生成）
+   * タブごとに独立、タブを閉じると削除
+   */
+  getTabSessionId(): string {
+    // メモリにキャッシュがあればそれを返す
+    if (this.tabSessionId) {
+      return this.tabSessionId;
+    }
+
+    // sessionStorageから取得
+    const existingId = sessionStorage.getItem('tab_session_id');
+    if (existingId && existingId.trim() !== '') {
+      this.tabSessionId = existingId;
+      return existingId;
+    }
+
+    // 新規生成
+    this.tabSessionId = this.generateUUID();
+    sessionStorage.setItem('tab_session_id', this.tabSessionId);
+    return this.tabSessionId;
+  }
+
+  /**
+   * セッションIDを取得（互換性のため残す）
+   * タブセッションIDを返す
+   */
+  getSessionId(): string {
+    return this.getTabSessionId();
   }
 
   /**


### PR DESCRIPTION
- データベースベースの会話管理システムを実装
- タブごとの独立した会話セッション管理
- ダッシュボードから特定の会話を直接開く機能
- セッション永続化とCookie管理（30日間保持）
- 新規/既存顧客の自動判定とフィルタリング
- メタデータによるフォーム情報の保存と表示
- 90秒タイムアウトでの自動返信機能
- URLハッシュによる会話ID指定機能