### PR TITLE
feat: チャットインタラクションフローの改善

### DIFF
--- a/frontend/src/__tests__/ChatInteraction.test.tsx
+++ b/frontend/src/__tests__/ChatInteraction.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import NewCustomerChat from '../NewCustomerChat';
+import CustomerInsightDashboard from '../CustomerInsightDashboard';
+
+// ActionCableサービスのモック
+vi.mock('../services/actionCable', () => ({
+  default: {
+    subscribeToConversation: vi.fn(),
+    sendMessage: vi.fn(),
+    unsubscribe: vi.fn()
+  }
+}));
+
+// SessionManagerのモック
+vi.mock('../services/sessionManager', () => ({
+  default: {
+    getUserId: () => 'test-user-123',
+    getTabSessionId: () => 'test-tab-456',
+    setCurrentConversationId: vi.fn(),
+    getCurrentConversationId: () => null
+  }
+}));
+
+describe('チャットインタラクションフロー', () => {
+  beforeEach(() => {
+    // 各テストの前にモックをリセット
+    vi.clearAllMocks();
+    // localStorageをクリア
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  describe('フォーム送信後の動作', () => {
+    it('フォーム送信後、ユーザーは追加のメッセージを送信できる', async () => {
+      const { container } = render(<NewCustomerChat />);
+      
+      // フォーム送信後の状態をシミュレート
+      // TODO: フォーム送信ロジックを実装後にテストを完成させる
+      
+      // メッセージ入力フィールドが存在することを確認
+      const messageInput = container.querySelector('input[type="text"]');
+      expect(messageInput).toBeInTheDocument();
+      
+      // メッセージ送信ボタンが存在することを確認
+      const sendButton = container.querySelector('button');
+      expect(sendButton).toBeInTheDocument();
+    });
+
+    it('企業側からの返信後、ユーザーはチャットを継続できる', async () => {
+      // TODO: 企業からの返信受信後の動作をテスト
+    });
+  });
+
+  describe('ダッシュボードのボタン表示ロジック', () => {
+    it('未対応の会話には「対応開始」ボタンのみ表示される', () => {
+      const mockPendingChat = {
+        id: '1',
+        status: 'pending' as const,
+        responseType: null,
+        companyName: 'テスト会社',
+        contactName: 'テスト太郎',
+        email: 'test@example.com',
+        message: 'テストメッセージ',
+        category: 'サポート',
+        timestamp: '2024-01-01 10:00',
+        customerType: 'new' as const
+      };
+
+      // ダッシュボードをレンダリング
+      render(<CustomerInsightDashboard />);
+      
+      // localStorageにテストデータを設定
+      localStorage.setItem('pendingChats', JSON.stringify([mockPendingChat]));
+      
+      // TODO: 実際のボタン表示ロジックをテスト
+    });
+
+    it('対応開始後は「チャットを確認」ボタンのみ表示される', () => {
+      const mockRespondingChat = {
+        id: '2',
+        status: 'responding' as const,
+        responseType: 'immediate' as const,
+        companyName: 'テスト会社2',
+        contactName: 'テスト花子',
+        email: 'test2@example.com',
+        message: 'テストメッセージ2',
+        category: 'サポート',
+        timestamp: '2024-01-01 11:00',
+        customerType: 'new' as const
+      };
+
+      // ダッシュボードをレンダリング
+      render(<CustomerInsightDashboard />);
+      
+      // localStorageにテストデータを設定
+      localStorage.setItem('pendingChats', JSON.stringify([mockRespondingChat]));
+      
+      // TODO: 実際のボタン表示ロジックをテスト
+    });
+
+    it('2営業日以内に返信を選択した場合も「チャットを確認」ボタンのみ表示される', () => {
+      const mockLaterResponseChat = {
+        id: '3',
+        status: 'pending' as const,
+        responseType: 'later' as const,
+        companyName: 'テスト会社3',
+        contactName: 'テスト次郎',
+        email: 'test3@example.com',
+        message: 'テストメッセージ3',
+        category: 'サポート',
+        timestamp: '2024-01-01 12:00',
+        customerType: 'new' as const
+      };
+
+      // ダッシュボードをレンダリング
+      render(<CustomerInsightDashboard />);
+      
+      // localStorageにテストデータを設定
+      localStorage.setItem('pendingChats', JSON.stringify([mockLaterResponseChat]));
+      
+      // TODO: 実際のボタン表示ロジックをテスト
+    });
+  });
+
+  describe('チャット継続性', () => {
+    it('フォーム送信後も同じ会話IDでチャットが継続される', async () => {
+      // TODO: 会話IDの永続性をテスト
+    });
+
+    it('企業側の返信が正しくユーザー側に表示される', async () => {
+      // TODO: リアルタイム通信のテスト
+    });
+  });
+});


### PR DESCRIPTION
・ フォーム送信後もユーザーがチャットを継続できるよう修正
・ ダッシュボードのボタン表示ロジックを実装
  ・ 未対応の会話には「対応開始」ボタンのみ表示
  ・ 対応開始後は「チャットを確認」ボタンのみ表示
  ・ responseTypeをデータベースに永続化
・ ActionCable接続の重複を防止
・ メッセージ二重送信の問題を修正
・ 新規/既存顧客の判定ロジックを改善